### PR TITLE
Make schema names ROS 2 compatible

### DIFF
--- a/ddsrecorder/test/blackbox/mcap/McapFileCreationTest.cpp
+++ b/ddsrecorder/test/blackbox/mcap/McapFileCreationTest.cpp
@@ -402,18 +402,18 @@ TEST(McapFileCreationTest, mcap_data_topic)
     auto messages = get_msgs_mcap(file_name, mcap_reader);
 
     std::string received_topic;
-    std::string received_data_type_name;
+    std::string received_data_schema_name;
 
     for (auto it = messages.begin(); it != messages.end(); it++)
     {
         received_topic = it->channel->topic;
-        received_data_type_name = it->schema->name;
+        received_data_schema_name = it->schema->name;
     }
     mcap_reader.close();
 
     // Test data
     ASSERT_EQ(received_topic, test::topic);
-    ASSERT_EQ(received_data_type_name, test::data_type_name);
+    ASSERT_EQ(received_data_schema_name, "fastdds/" + test::data_type_name);
 
 }
 

--- a/ddsrecorder_participants/src/cpp/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/mcap/McapHandler.cpp
@@ -19,7 +19,6 @@
 #define MCAP_IMPLEMENTATION  // Define this in exactly one .cpp file
 
 #include <cstdio>
-#include <regex>
 
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/exception/InconsistencyException.hpp>
@@ -133,15 +132,10 @@ void McapHandler::add_schema(
         // Schema not found, generate from dynamic type and store
         std::string schema_text = generate_ros2_schema(dynamic_type);
 
-        // Convert to ROS 2 compatible schema name (add namespace prefix and remove non-alphanumerical characters)
-        // NOTE: Not all ROS 2 format rules are automatically fulfilled via this transformation. For example, this
-        // transform does not enforce the first character to be an uppercase letter
-        std::string schema_name = "fastdds/" + std::regex_replace(type_name, std::regex("([^A-Za-z0-9])"), "");
-
-        logInfo(DDSRECORDER_MCAP_HANDLER, "\nAdding schema with name " << schema_name << " :\n" << schema_text << "\n");
+        logInfo(DDSRECORDER_MCAP_HANDLER, "\nAdding schema with name " << type_name << " :\n" << schema_text << "\n");
 
         // Create schema and add it to writer and to schemas map
-        mcap::Schema new_schema(schema_name, "ros2msg", schema_text);
+        mcap::Schema new_schema("fastdds/" + type_name, "ros2msg", schema_text);
         // WARNING: passing as non-const to MCAP library
         mcap_writer_.addSchema(new_schema);
         schemas_.insert({type_name, std::move(new_schema)});

--- a/ddsrecorder_participants/src/cpp/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/mcap/McapHandler.cpp
@@ -19,6 +19,7 @@
 #define MCAP_IMPLEMENTATION  // Define this in exactly one .cpp file
 
 #include <cstdio>
+#include <regex>
 
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/exception/InconsistencyException.hpp>
@@ -132,10 +133,15 @@ void McapHandler::add_schema(
         // Schema not found, generate from dynamic type and store
         std::string schema_text = generate_ros2_schema(dynamic_type);
 
-        logInfo(DDSRECORDER_MCAP_HANDLER, "\nAdding schema with name " << type_name << " :\n" << schema_text << "\n");
+        // Convert to ROS 2 compatible schema name (add namespace prefix and remove non-alphanumerical characters)
+        // NOTE: Not all ROS 2 format rules are automatically fulfilled via this transformation. For example, this
+        // transform does not enforce the first character to be an uppercase letter
+        std::string schema_name = "fastdds/" + std::regex_replace(type_name, std::regex("([^A-Za-z0-9])"), "");
+
+        logInfo(DDSRECORDER_MCAP_HANDLER, "\nAdding schema with name " << schema_name << " :\n" << schema_text << "\n");
 
         // Create schema and add it to writer and to schemas map
-        mcap::Schema new_schema(type_name, "ros2msg", schema_text);
+        mcap::Schema new_schema(schema_name, "ros2msg", schema_text);
         // WARNING: passing as non-const to MCAP library
         mcap_writer_.addSchema(new_schema);
         schemas_.insert({type_name, std::move(new_schema)});


### PR DESCRIPTION
Generated schemas containing type names internally generated for Fast DDS TypeLookupService (type_GuidPrefix_EntityId_SequenceNumber) are not compatible with some ROS 2 specific libraries (e.g. [mcap-ros2-support](https://pypi.org/project/mcap-ros2-support/) ). This is addressed in https://github.com/eProsima/DDS-Pipe/pull/20, however, also the schema names must follow certain rules (e.g. they must be preceded by a namespace prefix).

Testing scenario:
- Publish a complex dynamic type (involving the use of TypeLookupService)
- Capture traffic with [DDS-Recorder](https://github.com/eProsima/DDS-Recorder)
- Read MCAP file from Python as in the following [example](https://mcap.dev/docs/python/ros2_noenv_example.html#reading-messages)

**Note**
Some of these ROS 2 format rules are enforced in this PR, but some others are still left for the user to respect (e.g. schema/type names cannot contain non-alphanumerical characters, and first character must be an uppercase letter).