### PR TITLE
McapHandler improvements

### DIFF
--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/mcap/McapHandler.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/mcap/McapHandler.hpp
@@ -134,7 +134,9 @@ public:
      * to be written with the next batch.
      * Previously created channels (for this type) associated with a blank schema are updated to use the new one.
      *
-     * If instance is STOPPED, received schema is not processed.
+     * If instance is STOPPED, received schema is not processed and a exception is thrown.
+     *
+     * @throw InconsistencyException if instance is STOPPED.
      *
      * @param [in] dynamic_type DynamicType containing the type information required to generate the schema.
      */
@@ -152,7 +154,9 @@ public:
      *                 and discarded otherwise.
      *   if PAUSED  -> the sample is inserted into \c pending_samples_paused_ queue.
      *
-     * If instance is STOPPED, received data is not processed.
+     * If instance is STOPPED, received data is not processed and a exception is thrown.
+     *
+     * @throw InconsistencyException if instance is STOPPED or an error occurs.
      *
      * @param [in] topic DDS topic associated to this sample.
      * @param [in] data Message to be added.

--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/mcap/McapHandlerConfiguration.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/mcap/McapHandlerConfiguration.hpp
@@ -29,7 +29,7 @@ struct McapHandlerConfiguration
 {
     McapHandlerConfiguration(
             const std::string& file_name,
-            const unsigned int& max_pending_samples,
+            const int& max_pending_samples,
             const unsigned int& buffer_size,
             const unsigned int& event_window,
             const unsigned int& cleanup_period,
@@ -49,7 +49,7 @@ struct McapHandlerConfiguration
     std::string file_name;
 
     //! Max number of messages to store in memory when schema not yet available
-    unsigned int max_pending_samples;
+    int max_pending_samples;
 
     //! Max number of elements to keep in memory prior to writting in disk (applies to started state)
     unsigned int buffer_size;

--- a/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
@@ -130,8 +130,8 @@ void McapHandler::add_schema(
     if (state_ == McapHandlerStateCode::STOPPED)
     {
         throw utils::InconsistencyException(
-                    STR_ENTRY << "Attempting to add schema through a stopped handler, dropping..."
-                    );
+                  STR_ENTRY << "Attempting to add schema through a stopped handler, dropping..."
+                  );
     }
 
     assert(nullptr != dynamic_type);
@@ -186,8 +186,8 @@ void McapHandler::add_data(
     if (state_ == McapHandlerStateCode::STOPPED)
     {
         throw utils::InconsistencyException(
-                    STR_ENTRY << "Attempting to add sample through a stopped handler, dropping..."
-                    );
+                  STR_ENTRY << "Attempting to add sample through a stopped handler, dropping..."
+                  );
     }
 
     // Add data to channel

--- a/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
@@ -129,10 +129,9 @@ void McapHandler::add_schema(
 
     if (state_ == McapHandlerStateCode::STOPPED)
     {
-        logWarning(
-            DDSRECORDER_MCAP_HANDLER,
-            "Attempting to add schema through a stopped handler, dropping...");
-        return;
+        throw utils::InconsistencyException(
+                    STR_ENTRY << "Attempting to add schema through a stopped handler, dropping..."
+                    );
     }
 
     assert(nullptr != dynamic_type);
@@ -186,10 +185,9 @@ void McapHandler::add_data(
 
     if (state_ == McapHandlerStateCode::STOPPED)
     {
-        logWarning(
-            DDSRECORDER_MCAP_HANDLER,
-            "Attempting to add sample through a stopped handler, dropping...");
-        return;
+        throw utils::InconsistencyException(
+                    STR_ENTRY << "Attempting to add sample through a stopped handler, dropping..."
+                    );
     }
 
     // Add data to channel

--- a/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
@@ -341,7 +341,12 @@ void McapHandler::stop()
             // Adds to buffer samples whose schema was not received while running
             add_pending_samples_nts_();
         }
-        dump_data_nts_();  // if prev_state == RUNNING -> writes buffer + added pending samples
+        else
+        {
+            // Free memory resources
+            pending_samples_.clear();
+        }
+        dump_data_nts_();  // if prev_state == RUNNING -> writes buffer + added pending samples (if !only_with_schema)
                            // if prev_state == PAUSED  -> writes added pending samples (if !only_with_schema)
     }
 }

--- a/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
@@ -488,7 +488,7 @@ void McapHandler::add_to_pending_nts_(
 {
     assert(configuration_.max_pending_samples != 0);
     if (configuration_.max_pending_samples > 0 &&
-            pending_samples_[topic.type_name].size() == configuration_.max_pending_samples)
+            pending_samples_[topic.type_name].size() == static_cast<unsigned int>(configuration_.max_pending_samples))
     {
         if (configuration_.only_with_schema)
         {

--- a/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
@@ -137,33 +137,40 @@ void McapHandler::add_schema(
 
     assert(nullptr != dynamic_type);
     std::string type_name = dynamic_type->get_name();
+
+    // Check if it exists already
+    if (received_types_.find(type_name) != received_types_.end())
     {
-        // Check if it exists already
-        if (schemas_.find(type_name) != schemas_.end())
-        {
-            return;
-        }
-
-        // Schema not found, generate from dynamic type and store
-        std::string schema_text = generate_ros2_schema(dynamic_type);
-
-        logInfo(DDSRECORDER_MCAP_HANDLER, "\nAdding schema with name " << type_name << " :\n" << schema_text << "\n");
-
-        // Create schema and add it to writer and to schemas map
-        mcap::Schema new_schema(type_name, "ros2msg", schema_text);
-        // WARNING: passing as non-const to MCAP library
-        mcap_writer_.addSchema(new_schema);
-        schemas_.insert({type_name, std::move(new_schema)});
+        return;
     }
+
+    // Schema not found, generate from dynamic type and store
+    std::string schema_text = generate_ros2_schema(dynamic_type);
+
+    logInfo(DDSRECORDER_MCAP_HANDLER, "\nAdding schema with name " << type_name << " :\n" << schema_text << "\n");
+
+    // Create schema and add it to writer and to schemas map
+    mcap::Schema new_schema(type_name, "ros2msg", schema_text);
+    // WARNING: passing as non-const to MCAP library
+    mcap_writer_.addSchema(new_schema);
 
     logInfo(DDSRECORDER_MCAP_HANDLER, "Schema created: " << type_name << ".");
 
-    // Check if there are any pending samples for this new schema. If so, add them to buffer.
-    auto it = pending_samples_.find(type_name);
-    if (it != pending_samples_.end())
+    auto it = schemas_.find(type_name);
+    if (it != schemas_.end())
+    {
+        // Update channels previously created with blank schema
+        update_channels_nts_(it->second.id, new_schema.id);
+    }
+    schemas_[type_name] = std::move(new_schema);
+    received_types_.insert(type_name);
+
+    // Check if there are any pending samples for this new schema. If so, add them.
+    if ((pending_samples_.find(type_name) != pending_samples_.end()) ||
+            (state_ == McapHandlerStateCode::PAUSED &&
+            (pending_samples_paused_.find(type_name) != pending_samples_paused_.end())))
     {
         add_pending_samples_nts_(type_name);
-        pending_samples_.erase(it);
     }
 }
 
@@ -229,42 +236,57 @@ void McapHandler::add_data(
                   );
     }
 
-    try
+    if (received_types_.count(topic.type_name) != 0)
     {
-        auto channel_id = get_channel_id_nts_(topic);
-        msg.channelId = channel_id;
+        // Schema available -> add to buffer
+        add_data_nts_(msg, topic);
     }
-    catch (const utils::Exception&)
+    else
     {
-        logInfo(
-            DDSRECORDER_MCAP_HANDLER,
-            "Schema for topic " << topic << " not yet available, inserting to pending samples queue.");
-
-        if (configuration_.max_pending_samples > 0 &&
-                pending_samples_[topic.type_name].size() == configuration_.max_pending_samples)
+        if (state_ == McapHandlerStateCode::RUNNING)
         {
-            pending_samples_[topic.type_name].pop();
+            if (configuration_.max_pending_samples == 0)
+            {
+                if (configuration_.only_with_schema)
+                {
+                    // No schema available + no pending samples + only_with_schema -> Discard message
+                    return;
+                }
+                else
+                {
+                    // No schema available + no pending samples -> Add to buffer with blank schema
+                    add_data_nts_(msg, topic);
+                }
+            }
+            else
+            {
+                logInfo(
+                    DDSRECORDER_MCAP_HANDLER,
+                    "Schema for topic " << topic << " not yet available, inserting to pending samples queue.");
+
+                add_to_pending_nts_(msg, topic);
+            }
         }
-        pending_samples_[topic.type_name].push({topic, msg});
+        else if (state_ == McapHandlerStateCode::PAUSED)
+        {
+            logInfo(
+                DDSRECORDER_MCAP_HANDLER,
+                "Schema for topic " << topic << " not yet available, inserting to (paused) pending samples queue.");
 
-        throw;
-    }
-
-    try
-    {
-        add_data_nts_(msg);
-    }
-    catch (const utils::Exception&)
-    {
-        throw utils::InconsistencyException(
-                  STR_ENTRY << "Error writting in MCAP a message in topic " << topic
-                  );
+            pending_samples_paused_[topic.type_name].push_back({topic, msg});
+        }
+        else
+        {
+            // Should not happen, protected with mutex and state verified at beginning
+            utils::tsnh(
+                utils::Formatter() << "Trying to add sample from a stopped instance.");
+        }
     }
 }
 
 void McapHandler::start()
 {
-    std::lock_guard<std::mutex> lock(state_mtx_);
+    std::lock_guard<std::mutex> lock(mtx_);
 
     // Store previous state to act differently depending on its value
     McapHandlerStateCode prev_state = state_;
@@ -284,7 +306,7 @@ void McapHandler::start()
 
         if (prev_state == McapHandlerStateCode::PAUSED)
         {
-            // Stop event routine (cleans buffer)
+            // Stop event routine (cleans buffers)
             stop_event_thread_nts_();
         }
     }
@@ -292,32 +314,43 @@ void McapHandler::start()
 
 void McapHandler::stop()
 {
-    std::lock_guard<std::mutex> lock(state_mtx_);
+    std::lock_guard<std::mutex> lock(mtx_);
 
     // Store previous state to act differently depending on its value
     McapHandlerStateCode prev_state = state_;
     state_ = McapHandlerStateCode::STOPPED;
 
-    if (prev_state == McapHandlerStateCode::RUNNING)
+    if (prev_state == McapHandlerStateCode::STOPPED)
     {
-        std::lock_guard<std::mutex> _(mtx_);
+        logWarning(
+            DDSRECORDER_MCAP_HANDLER,
+            "Ignoring stop command, instance already stopped.");
+    }
+    else
+    {
+        logInfo(
+            DDSRECORDER_MCAP_HANDLER,
+            "Stopping handler.");
+
+        if (prev_state == McapHandlerStateCode::PAUSED)
+        {
+            // Stop event routine (cleans buffers)
+            stop_event_thread_nts_();
+        }
+
         if (!configuration_.only_with_schema)
         {
-            // Write samples whose schema was not received while RUNNNING
+            // Adds to buffer samples whose schema was not received while running
             add_pending_samples_nts_();
         }
-        dump_data_nts_();
-    }
-    else if (prev_state == McapHandlerStateCode::PAUSED)
-    {
-        // Stop event routine (cleans buffer)
-        stop_event_thread_nts_();
+        dump_data_nts_();  // if prev_state == RUNNING -> writes buffer + added pending samples
+                           // if prev_state == PAUSED  -> writes added pending samples (if !only_with_schema)
     }
 }
 
 void McapHandler::pause()
 {
-    std::lock_guard<std::mutex> lock(state_mtx_);
+    std::lock_guard<std::mutex> lock(mtx_);
 
     // Store previous state to act differently depending on its value
     McapHandlerStateCode prev_state = state_;
@@ -337,27 +370,22 @@ void McapHandler::pause()
 
         if (prev_state == McapHandlerStateCode::RUNNING)
         {
-            std::lock_guard<std::mutex> _(mtx_);
-            if (!configuration_.only_with_schema)
-            {
-                // Write samples whose schema was not received while RUNNNING
-                add_pending_samples_nts_();
-            }
             // Write data stored in buffer
             dump_data_nts_();
-            // Remove pending samples (if not written)
-            clear_all_nts_();
+            // Clear buffer
+            // NOTE: not really needed, dump_data_nts_ already writes and pops all samples
+            samples_buffer_.clear();
         }
 
         // Launch event thread routine
-        event_flag_ = EventCode::untriggered;  // No need to take event mutex (protected by state_mtx_)
+        event_flag_ = EventCode::untriggered;  // No need to take event mutex (protected by mtx_)
         event_thread_ = std::thread(&McapHandler::event_thread_routine_, this);
     }
 }
 
 void McapHandler::trigger_event()
 {
-    std::lock_guard<std::mutex> lock(state_mtx_);
+    std::lock_guard<std::mutex> lock(mtx_);
 
     if (state_ != McapHandlerStateCode::PAUSED)
     {
@@ -398,42 +426,127 @@ mcap::Timestamp McapHandler::now()
 }
 
 void McapHandler::add_data_nts_(
+        const Message& msg,
+        bool direct_write /* false */)
+{
+    if (direct_write)
+    {
+        try
+        {
+            // Write to MCAP file
+            write_message_nts_(msg);
+        }
+        catch (const utils::InconsistencyException& e)
+        {
+            logError(DDSRECORDER_MCAP_HANDLER, "Error writting message in channel " << msg.channelId << ". Error message:\n " <<
+                    e.what());
+        }
+    }
+    else
+    {
+        samples_buffer_.push_back(msg);
+        if (state_ == McapHandlerStateCode::RUNNING && samples_buffer_.size() == configuration_.buffer_size)
+        {
+            logInfo(DDSRECORDER_MCAP_HANDLER, "Full buffer, writting to disk...");
+            dump_data_nts_();
+        }
+    }
+}
+
+void McapHandler::add_data_nts_(
+        Message& msg,
+        const DdsTopic& topic,
+        bool direct_write /* false */)
+{
+    try
+    {
+        auto channel_id = get_channel_id_nts_(topic);
+        msg.channelId = channel_id;
+    }
+    catch (const utils::InconsistencyException& e)
+    {
+        logWarning(DDSRECORDER_MCAP_HANDLER, "Error adding message in topic " << topic << ". Error message:\n " <<
+                e.what());
+        return;
+    }
+    add_data_nts_(msg, direct_write);
+}
+
+void McapHandler::write_message_nts_(
         const Message& msg)
 {
-    samples_buffer_.push_back(msg);
-    if (state_ == McapHandlerStateCode::RUNNING && samples_buffer_.size() == configuration_.buffer_size)
+    auto status = mcap_writer_.write(msg);
+    if (!status.ok())
     {
-        logInfo(DDSRECORDER_MCAP_HANDLER, "Full buffer, writting to disk...");
-        dump_data_nts_();
+        throw utils::InconsistencyException(
+                  STR_ENTRY << "Error writting in MCAP, error message: " << status.message
+                  );
     }
+}
+
+void McapHandler::add_to_pending_nts_(
+        Message& msg,
+        const DdsTopic& topic)
+{
+    assert(configuration_.max_pending_samples != 0);
+    if (configuration_.max_pending_samples > 0 &&
+            pending_samples_[topic.type_name].size() == configuration_.max_pending_samples)
+    {
+        if (configuration_.only_with_schema)
+        {
+            // Discard oldest message in pending samples
+            logWarning(DDSRECORDER_MCAP_HANDLER,
+                    "Dropping pending sample in type " << topic.type_name << ": buffer limit (" << configuration_.max_pending_samples <<
+                    ") reached.");
+        }
+        else
+        {
+            logInfo(DDSRECORDER_MCAP_HANDLER,
+                    "Buffer limit (" << configuration_.max_pending_samples <<  ") reached for type " << topic.type_name <<
+                    ": writing oldest sample without schema.");
+
+            // Write oldest message without schema
+            auto& oldest_sample = pending_samples_[topic.type_name].front();
+            add_data_nts_(oldest_sample.second, oldest_sample.first);
+        }
+        pending_samples_[topic.type_name].pop_front();
+    }
+    pending_samples_[topic.type_name].push_back({topic, msg});
 }
 
 void McapHandler::add_pending_samples_nts_(
         const std::string& schema_name)
 {
-    assert(pending_samples_.find(schema_name) != pending_samples_.end());
-    auto& pending_queue = pending_samples_[schema_name];
+    logInfo(DDSRECORDER_MCAP_HANDLER, "Adding pending samples for type: " << schema_name << ".");
 
-    logInfo(DDSRECORDER_MCAP_HANDLER, "Sending pending samples of type: " << schema_name << ".");
-
-    mcap::ChannelId channel_id;
-    while (!pending_queue.empty())
+    if (pending_samples_.find(schema_name) != pending_samples_.end())
     {
-        auto& sample = pending_queue.front();
-        channel_id = get_channel_id_nts_(sample.first);
-        auto& msg = sample.second;
-        msg.channelId = channel_id;
-        try
-        {
-            add_data_nts_(msg);
-        }
-        catch (const utils::Exception&)
-        {
-            throw utils::InconsistencyException(
-                      STR_ENTRY << "Error writting in MCAP a message in topic " << sample.first
-                      );
-        }
-        pending_queue.pop();
+        // Move samples from pending_samples to buffer
+        // NOTE: directly write to MCAP when PAUSED, as these correspond to samples that were previously received in
+        // RUNNING state (hence to avoid being cleaned by event thread)
+        add_pending_samples_nts_(pending_samples_[schema_name], state_ == McapHandlerStateCode::PAUSED);
+        pending_samples_.erase(schema_name);
+    }
+
+    if (state_ == McapHandlerStateCode::PAUSED &&
+            (pending_samples_paused_.find(schema_name) != pending_samples_paused_.end()))
+    {
+        // Move samples from pending_samples_paused to buffer, from where they will be written if event received
+        add_pending_samples_nts_(pending_samples_paused_[schema_name]);
+        pending_samples_paused_.erase(schema_name);
+    }
+}
+
+void McapHandler::add_pending_samples_nts_(
+        pending_list& pending_samples,
+        bool direct_write /* false */)
+{
+    while (!pending_samples.empty())
+    {
+        // Move samples from pending list to buffer, or write them directly to MCAP file
+        auto& sample = pending_samples.front();
+        add_data_nts_(sample.second, sample.first, direct_write);
+        pending_samples.pop_front();
     }
 }
 
@@ -441,15 +554,10 @@ void McapHandler::add_pending_samples_nts_()
 {
     logInfo(DDSRECORDER_MCAP_HANDLER, "Adding pending samples for all types.");
 
-    for (auto& pending_type: pending_samples_)
+    auto pending_types = utils::get_keys(pending_samples_);
+    for (auto& pending_type: pending_types)
     {
-        logInfo(DDSRECORDER_MCAP_HANDLER, "Blank schema created for type: " << pending_type.first << ".");
-
-        mcap::Schema blank_schema(pending_type.first, "ros2msg", "");
-        mcap_writer_.addSchema(blank_schema);
-        schemas_.insert({pending_type.first, std::move(blank_schema)});
-
-        add_pending_samples_nts_(pending_type.first);
+        add_pending_samples_nts_(pending_type);
     }
 }
 
@@ -509,6 +617,37 @@ void McapHandler::event_thread_routine_()
         else
         {
             logInfo(DDSRECORDER_MCAP_HANDLER, "Event triggered: dumping buffered data.");
+
+            if (!(configuration_.max_pending_samples == 0 && configuration_.only_with_schema))
+            {
+                // Move (paused) pending samples to buffer (or pending samples) prior to dumping
+                for (auto& pending_type : pending_samples_paused_)
+                {
+                    auto type_name = pending_type.first;
+                    auto& pending_list = pending_type.second;
+                    while (!pending_list.empty())
+                    {
+                        auto& sample = pending_list.front();
+                        if (configuration_.max_pending_samples == 0)
+                        {
+                            if (configuration_.only_with_schema)
+                            {
+                                // Cannot happen (outter if)
+                            }
+                            else
+                            {
+                                // Add to buffer with blank schema
+                                add_data_nts_(sample.second, sample.first);
+                            }
+                        }
+                        else
+                        {
+                            add_to_pending_nts_(sample.second, sample.first);
+                        }
+                        pending_list.pop_front();
+                    }
+                }
+            }
             dump_data_nts_();
         }
     }
@@ -523,6 +662,14 @@ void McapHandler::remove_outdated_samples_nts_()
             {
                 return sample.logTime < threshold;
             });
+
+    for (auto& pending_type : pending_samples_paused_)
+    {
+        pending_type.second.remove_if([&](auto& sample)
+                {
+                    return sample.second.logTime < threshold;
+                });
+    }
 }
 
 void McapHandler::stop_event_thread_nts_()
@@ -540,19 +687,8 @@ void McapHandler::stop_event_thread_nts_()
         event_cv_.notify_one();
         event_thread_.join();
     }
-    std::lock_guard<std::mutex> _(mtx_);
-    clear_all_nts_();
-}
-
-void McapHandler::clear_all_nts_()
-{
-    logInfo(DDSRECORDER_MCAP_HANDLER, "Cleaning all buffers.");
-
-    // Clear samples buffer
     samples_buffer_.clear();
-
-    // Clear pending samples
-    pending_samples_.clear();
+    pending_samples_paused_.clear();
 }
 
 void McapHandler::dump_data_nts_()
@@ -562,13 +698,18 @@ void McapHandler::dump_data_nts_()
     while (!samples_buffer_.empty())
     {
         auto& sample = samples_buffer_.front();
-        auto status = mcap_writer_.write(sample);
-        if (!status.ok())
+        try
         {
-            throw utils::InconsistencyException(
-                      STR_ENTRY << "Error writting in MCAP"
-                      );
+            // Write to MCAP file
+            write_message_nts_(sample);
         }
+        catch (const utils::InconsistencyException& e)
+        {
+            logError(DDSRECORDER_MCAP_HANDLER, "Error writting message in channel " << sample.channelId << ". Error message:\n " <<
+                    e.what());
+        }
+
+        // Pop written sample (even if exception thrown)
         samples_buffer_.pop_front();
     }
 }
@@ -577,7 +718,30 @@ mcap::ChannelId McapHandler::create_channel_id_nts_(
         const DdsTopic& topic)
 {
     // Find schema
-    auto schema_id = get_schema_id_nts_(topic.type_name);
+    mcap::SchemaId schema_id;
+    try
+    {
+        schema_id = get_schema_id_nts_(topic.type_name);
+    }
+    catch (const utils::InconsistencyException&)
+    {
+        if (!configuration_.only_with_schema)
+        {
+            logInfo(DDSRECORDER_MCAP_HANDLER,
+                    "Schema not found for type: " << topic.type_name << ". Creating blank schema...");
+
+            mcap::Schema blank_schema(topic.type_name, "ros2msg", "");
+            mcap_writer_.addSchema(blank_schema);
+            schemas_.insert({topic.type_name, std::move(blank_schema)});
+
+            schema_id = blank_schema.id;
+        }
+        else
+        {
+            // Propagate exception
+            throw;
+        }
+    }
 
     // Create new channel
     mcap::KeyValueMap metadata = {};
@@ -585,7 +749,7 @@ mcap::ChannelId McapHandler::create_channel_id_nts_(
     mcap::Channel new_channel(topic.m_topic_name, "cdr", schema_id, metadata);
     mcap_writer_.addChannel(new_channel);
     auto channel_id = new_channel.id;
-    channels_.insert({topic.m_topic_name, std::move(new_channel)});
+    channels_.insert({topic, std::move(new_channel)});
     logInfo(DDSRECORDER_MCAP_HANDLER, "Channel created: " << topic << ".");
 
     return channel_id;
@@ -594,7 +758,7 @@ mcap::ChannelId McapHandler::create_channel_id_nts_(
 mcap::ChannelId McapHandler::get_channel_id_nts_(
         const DdsTopic& topic)
 {
-    auto it = channels_.find(topic.m_topic_name);
+    auto it = channels_.find(topic);
     if (it != channels_.end())
     {
         return it->second.id;
@@ -602,6 +766,24 @@ mcap::ChannelId McapHandler::get_channel_id_nts_(
 
     // If it does not exist yet, create it (call it with mutex taken)
     return create_channel_id_nts_(topic);
+}
+
+void McapHandler::update_channels_nts_(
+        const mcap::SchemaId& old_schema_id,
+        const mcap::SchemaId& new_schema_id)
+{
+    for (auto& channel : channels_)
+    {
+        if (channel.second.schemaId == old_schema_id)
+        {
+            logInfo(DDSRECORDER_MCAP_HANDLER, "Updating channel in topic " << channel.first.m_topic_name << ".");
+
+            assert(channel.first.m_topic_name == channel.second.topic);
+            mcap::Channel new_channel(channel.second.topic, "cdr", new_schema_id, channel.second.metadata);
+            mcap_writer_.addChannel(new_channel);
+            channel.second = std::move(new_channel);
+        }
+    }
 }
 
 mcap::SchemaId McapHandler::get_schema_id_nts_(

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
@@ -78,7 +78,7 @@ public:
     // Specs
     unsigned int n_threads = 12;
     unsigned int max_history_depth = 5000;
-    unsigned int max_pending_samples = 0;  // 0 <-> no limit
+    int max_pending_samples = 5000;  // -1 <-> no limit || 0 <-> no pending samples
     unsigned int cleanup_period;
 
 protected:

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -37,6 +37,7 @@ namespace ddsrecorder {
 namespace yaml {
 
 using namespace eprosima::ddspipe::core;
+using namespace eprosima::ddspipe::core::types;
 using namespace eprosima::ddspipe::participants;
 using namespace eprosima::ddspipe::participants::rtps;
 using namespace eprosima::ddspipe::yaml;
@@ -115,13 +116,13 @@ void ReplayerConfiguration::load_ddsreplayer_configuration_(
         // from which a response is expected.
         // Hence, if these topics are not blocked, the client would wrongly believe DDS-Replayer is a server, thus
         // sending a request for which a response will not be received.
-        types::WildcardDdsFilterTopic rpc_request_topic, rpc_response_topic;
+        WildcardDdsFilterTopic rpc_request_topic, rpc_response_topic;
         rpc_request_topic.topic_name.set_value("rq/*");
         rpc_response_topic.topic_name.set_value("rr/*");
         blocklist.insert(
-            utils::Heritable<types::WildcardDdsFilterTopic>::make_heritable(rpc_request_topic));
+            utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_request_topic));
         blocklist.insert(
-            utils::Heritable<types::WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
+            utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
     }
     catch (const std::exception& e)
     {
@@ -194,7 +195,7 @@ void ReplayerConfiguration::load_specs_configuration_(
     {
         max_history_depth = YamlReader::get_positive_int(yml, MAX_HISTORY_DEPTH_TAG);
         // Set default value for history
-        types::TopicQoS::default_history_depth.store(max_history_depth);
+        TopicQoS::default_history_depth.store(max_history_depth);
     }
 
     // Get wait all acknowledged timeout
@@ -212,27 +213,27 @@ void ReplayerConfiguration::load_dds_configuration_(
     // Get optional DDS domain
     if (YamlReader::is_tag_present(yml, DOMAIN_ID_TAG))
     {
-        replayer_configuration->domain = YamlReader::get<types::DomainId>(yml, DOMAIN_ID_TAG, version);
+        replayer_configuration->domain = YamlReader::get<DomainId>(yml, DOMAIN_ID_TAG, version);
     }
 
     /////
     // Get optional allowlist
     if (YamlReader::is_tag_present(yml, ALLOWLIST_TAG))
     {
-        allowlist = YamlReader::get_set<utils::Heritable<types::IFilterTopic>>(yml, ALLOWLIST_TAG, version);
+        allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG, version);
 
         // Add to allowlist always the type object topic
-        types::WildcardDdsFilterTopic internal_topic;
-        internal_topic.topic_name.set_value(types::TYPE_OBJECT_TOPIC_NAME);
+        WildcardDdsFilterTopic internal_topic;
+        internal_topic.topic_name.set_value(TYPE_OBJECT_TOPIC_NAME);
         allowlist.insert(
-            utils::Heritable<types::WildcardDdsFilterTopic>::make_heritable(internal_topic));
+            utils::Heritable<WildcardDdsFilterTopic>::make_heritable(internal_topic));
     }
 
     /////
     // Get optional blocklist
     if (YamlReader::is_tag_present(yml, BLOCKLIST_TAG))
     {
-        blocklist = YamlReader::get_set<utils::Heritable<types::IFilterTopic>>(yml, BLOCKLIST_TAG, version);
+        blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG, version);
     }
 
     /////
@@ -240,7 +241,7 @@ void ReplayerConfiguration::load_dds_configuration_(
     if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
     {
         // WARNING: Parse builtin topics AFTER specs, as some topic-specific default values are set there
-        builtin_topics = YamlReader::get_set<utils::Heritable<types::DistributedTopic>>(yml, BUILTIN_TAG,
+        builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
                         version);
     }
 }

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -196,14 +196,6 @@ std::set<utils::Heritable<DistributedTopic>> DdsReplayer::generate_builtin_topic
 {
     std::set<utils::Heritable<DistributedTopic>> builtin_topics = configuration.builtin_topics;
 
-    // Cast to DdsTopic so both topic and type names are taken into account on lookups
-    std::set<utils::Heritable<DdsTopic>> builtin_topics_dds{};
-    for (auto topic : builtin_topics)
-    {
-        auto dds_topic = utils::Heritable<DdsTopic>(topic);
-        builtin_topics_dds.insert(dds_topic);
-    }
-
     mcap::McapReader mcap_reader;
 
     auto status = mcap_reader.open(input_file);
@@ -253,9 +245,10 @@ std::set<utils::Heritable<DistributedTopic>> DdsReplayer::generate_builtin_topic
         channel_topic->m_topic_name = topic_name;
         channel_topic->type_name = type_name;
 
-        if (builtin_topics_dds.count(channel_topic) == 1)
+        if (builtin_topics.count(channel_topic) == 1)
         {
             // Already present in builtin_topics list, using qos provided through configuration
+            // NOTE: also covers situation where there are channels for same topic with and without (blank) schema
             continue;
         }
 

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -7,9 +7,9 @@ Forthcoming Version
 
 Next release will include *DDS Replay tool*, supporting the following **Replay features**:
 
-* Supports setting begin and end times (``begin-time`` / ``end-time``).
-* Supports setting a replay start time (``start-replay-time``).
-* Supports playing stored data at a specific playback ``rate``.
+* Supports setting :ref:`begin <replayer_replay_configuration_begintime>` and :ref:`end <replayer_replay_configuration_endtime>` times (``begin-time`` / ``end-time``).
+* Supports setting a replay :ref:`start <replayer_replay_configuration_startreplaytime>` time (``start-replay-time``).
+* Supports playing stored data at a specific playback :ref:`rate <replayer_replay_configuration_playbackrate>` (``rate``).
 * Supports sending dynamic types stored in input MCAP file.
 
 Next release will include the following **User Interface features**:
@@ -23,10 +23,15 @@ Next release will include the following (*DDS Replay tool*) **Configuration feat
 * Support configuration related to DDS communication.
 * Support configuration of playback settings.
 * Support configuration of the internal operation of the DDS Replayer.
+* Support enabling/disabling dynamic types dispatch (see :ref:`Only With Type <replayer_replay_configuration_replaytypes>`).
 
 Next release will include the following **Recording features**:
 
-* Supports recording messages with unknown (dynamic) data type.
+* Supports recording messages with unknown (dynamic) data type, and to only record data whose type is known (see :ref:`Only With Type <recorder_usage_configuration_onlywithtype>`).
+
+Next release will include the following (*DDS Recorder tool*) **Configuration features**:
+
+* Support record only data whose (dynamic) type is known: ``only-with-type: true`` (see :ref:`Only With Type <recorder_usage_configuration_onlywithtype>`).
 
 Next release will include the following **Documentation features**:
 

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -405,7 +405,13 @@ Hence, note that memory consumption would continuously grow whenever a sample wi
 
 To avoid the exhaustion of memory resources in such scenarios, a configuration option is provided which lets the user set a limit on memory usage.
 The ``max-pending-samples`` parameter allows to configure the size of the aforementioned circular buffers **for each topic** that is discovered.
-The default value is equal to ``0`` samples (**no limit**).
+The default value is equal to ``5000`` samples, with ``-1`` meaning no limit, and ``0`` no pending samples.
+
+Depending on the combination of this configuration option and the value of ``only-with-type``, the following situations may arise when a message with unknown type is received:
+
+* If ``max-pending-samples`` is ``-1``, or if it is greater than ``0`` and the circular buffer is not full, the sample is added to the collection.
+* If ``max-pending-samples`` is greater than ``0`` and the circular buffer reaches its maximum capacity, the oldest sample with same type as the received one is popped, and either written without type (``only-with-type: false``) or discarded (``only-with-type: true``).
+* If ``max-pending-samples`` is ``0``, the message is written without type if ``only-with-type: false``, and discarded otherwise.
 
 Cleanup Period
 ^^^^^^^^^^^^^^

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -271,10 +271,14 @@ However, a user might be interested in only replaying data relative to a specifi
 
 Messages recorded/sent (see :ref:`Log Publish Time <recorder_usage_configuration_logpublishtime>`) before ``begin-time`` will not be played back by a |ddsreplayer| instance.
 
+.. _replayer_replay_configuration_endtime:
+
 End Time
 ^^^^^^^^
 
 As with ``begin-time``, a user can discard messages recorded/sent after a specific timepoint set through the ``end-time`` tag, which follows the format described in :ref:`Begin Time <replayer_replay_configuration_begintime>`.
+
+.. _replayer_replay_configuration_startreplaytime:
 
 Start Replay Time
 ^^^^^^^^^^^^^^^^^
@@ -282,12 +286,16 @@ Start Replay Time
 This configuration option (``start-replay-time``) allows to start replaying data at a certain timepoint following the format described in :ref:`Begin Time <replayer_replay_configuration_begintime>`.
 If the provided timepoint already expired, the replayer starts publishing messages right away.
 
+.. _replayer_replay_configuration_playbackrate:
+
 Playback Rate
 ^^^^^^^^^^^^^
 
 By default, data is replayed at the same rate it was published/received.
 However, a user might be interested in playing messages back at a rate different than the original one.
 This can be accomplished through the playback ``rate`` tag, which accepts positive float values (e.g. 0.5 <--> half speed || 2 <--> double speed).
+
+.. _replayer_replay_configuration_replaytypes:
 
 Replay Types
 ^^^^^^^^^^^^


### PR DESCRIPTION
After:
- https://github.com/eProsima/DDS-Record-Replay/pull/58

This PR tackles some inconsistencies introduced when adding the ``only-with-type`` configuration option, and extends the accepted values for ``max-pending-samples``, now being possible to have none, infinite or a finite number of pending samples.