### PR TITLE
Write metadata version prior to dynamic types attachment

### DIFF
--- a/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
@@ -109,14 +109,14 @@ McapHandler::~McapHandler()
     // Stop handler prior to destruction
     stop();
 
+    // Write version metadata in MCAP file
+    write_version_metadata_();
+
     // Serialize and store dynamic types associated to all added schemas
     if (configuration_.record_types)
     {
         store_dynamic_types_();
     }
-
-    // Write version metadata in MCAP file
-    write_version_metadata_();
 
     // Close writer and output file
     mcap_writer_.close();

--- a/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/mcap/McapHandler.cpp
@@ -110,6 +110,7 @@ McapHandler::~McapHandler()
     stop();
 
     // Write version metadata in MCAP file
+    // WARNING: write version metadata prior to dynamic types attachment to avoid overlapping issue
     write_version_metadata_();
 
     // Serialize and store dynamic types associated to all added schemas


### PR DESCRIPTION
This PR is a workaround for an issue encountered in mcap c++ library; writing a metadata after an attachment seems to cause overlapping, not being able to properly parse the attachment afterwards. Inverting the writing order seems to be sufficient to circumvent the problem.