### PR TITLE
Manually fix a set of Topic QoS, and implement the max-tx-rate

### DIFF
--- a/ddsrecorder/src/cpp/main.cpp
+++ b/ddsrecorder/src/cpp/main.cpp
@@ -67,11 +67,7 @@ std::unique_ptr<eprosima::utils::event::FileWatcherHandler> create_filewatcher(
                 try
                 {
                     eprosima::ddsrecorder::yaml::RecorderConfiguration new_configuration(file_path);
-                    // Create new allowed topics list
-                    auto new_allowed_topics = std::make_shared<core::AllowedTopicList>(
-                        new_configuration.allowlist,
-                        new_configuration.blocklist);
-                    recorder->reload_allowed_topics(new_allowed_topics);
+                    recorder->reload_configuration(new_configuration);
                 }
                 catch (const std::exception& e)
                 {
@@ -102,11 +98,7 @@ std::unique_ptr<eprosima::utils::event::PeriodicEventHandler> create_periodic_ha
                 try
                 {
                     eprosima::ddsrecorder::yaml::RecorderConfiguration new_configuration(file_path);
-                    // Create new allowed topics list
-                    auto new_allowed_topics = std::make_shared<core::AllowedTopicList>(
-                        new_configuration.allowlist,
-                        new_configuration.blocklist);
-                    recorder->reload_allowed_topics(new_allowed_topics);
+                    recorder->reload_configuration(new_configuration);
                 }
                 catch (const std::exception& e)
                 {

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
@@ -33,11 +33,6 @@ DdsRecorder::DdsRecorder(
         const DdsRecorderStateCode& init_state,
         const std::string& file_name)
 {
-    // Create allowed topics list
-    auto allowed_topics = std::make_shared<AllowedTopicList>(
-        configuration.allowlist,
-        configuration.blocklist);
-
     // Create Discovery Database
     discovery_database_ =
             std::make_shared<DiscoveryDatabase>();
@@ -116,19 +111,16 @@ DdsRecorder::DdsRecorder(
     // Create DDS Pipe
     pipe_ = std::make_unique<DdsPipe>(
         configuration.ddspipe_configuration,
-        allowed_topics,
         discovery_database_,
         payload_pool_,
         participants_database_,
-        thread_pool_,
-        configuration.builtin_topics,
-        true);
+        thread_pool_);
 }
 
-utils::ReturnCode DdsRecorder::reload_allowed_topics(
-        const std::shared_ptr<AllowedTopicList>& allowed_topics)
+utils::ReturnCode DdsRecorder::reload_configuration(
+        const yaml::RecorderConfiguration& new_configuration)
 {
-    return pipe_->reload_allowed_topics(allowed_topics);
+    return pipe_->reload_configuration(new_configuration.ddspipe_configuration);
 }
 
 void DdsRecorder::start()

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
@@ -115,6 +115,7 @@ DdsRecorder::DdsRecorder(
 
     // Create DDS Pipe
     pipe_ = std::make_unique<DdsPipe>(
+        configuration.ddspipe_configuration,
         allowed_topics,
         discovery_database_,
         payload_pool_,

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
@@ -77,8 +77,7 @@ public:
      * @return \c RETCODE_OK if allowed topics list has been updated correctly
      * @return \c RETCODE_NO_DATA if new allowed topics list is the same as the previous one
      */
-    utils::ReturnCode reload_allowed_topics(
-            const std::shared_ptr<ddspipe::core::AllowedTopicList>& allowed_topics);
+    utils::ReturnCode reload_configuration(const yaml::RecorderConfiguration& new_configuration);
 
     //! Start recorder (\c mcap_handler_)
     void start();

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
@@ -77,7 +77,8 @@ public:
      * @return \c RETCODE_OK if allowed topics list has been updated correctly
      * @return \c RETCODE_NO_DATA if new allowed topics list is the same as the previous one
      */
-    utils::ReturnCode reload_configuration(const yaml::RecorderConfiguration& new_configuration);
+    utils::ReturnCode reload_configuration(
+            const yaml::RecorderConfiguration& new_configuration);
 
     //! Start recorder (\c mcap_handler_)
     void start();

--- a/ddsrecorder/test/blackbox/mcap/McapFileCreationTest.cpp
+++ b/ddsrecorder/test/blackbox/mcap/McapFileCreationTest.cpp
@@ -88,10 +88,10 @@ std::unique_ptr<DdsRecorder> create_recorder(
     YAML::Node yml;
 
     eprosima::ddsrecorder::yaml::RecorderConfiguration configuration(yml);
-    configuration.downsampling = downsampling;
+    configuration.topic_qos.downsampling = downsampling;
     // Set default value for downsampling
     // TODO: Change mechanism setting topic qos' default values from specs
-    eprosima::ddspipe::core::types::TopicQoS::default_topic_qos->downsampling.set_value(downsampling);
+    eprosima::ddspipe::core::types::TopicQoS::default_topic_qos.set_value(configuration.topic_qos);
     configuration.event_window = event_window;
     eprosima::ddspipe::core::types::DomainId domainId;
     domainId.domain_id = test::DOMAIN;

--- a/ddsrecorder/test/blackbox/mcap/McapFileCreationTest.cpp
+++ b/ddsrecorder/test/blackbox/mcap/McapFileCreationTest.cpp
@@ -91,7 +91,7 @@ std::unique_ptr<DdsRecorder> create_recorder(
     configuration.downsampling = downsampling;
     // Set default value for downsampling
     // TODO: Change mechanism setting topic qos' default values from specs
-    eprosima::ddspipe::core::types::TopicQoS::default_downsampling.store(downsampling);
+    eprosima::ddspipe::core::types::TopicQoS::default_topic_qos->downsampling.set_value(downsampling);
     configuration.event_window = event_window;
     eprosima::ddspipe::core::types::DomainId domainId;
     domainId.domain_id = test::DOMAIN;

--- a/ddsrecorder_participants/include/ddsrecorder_participants/replayer/McapReaderParticipant.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/replayer/McapReaderParticipant.hpp
@@ -70,6 +70,10 @@ public:
     DDSRECORDER_PARTICIPANTS_DllAPI
     bool is_rtps_kind() const noexcept override;
 
+    //! Override topic_qos() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    ddspipe::core::types::TopicQoS topic_qos() const noexcept override;
+
     //! Override create_writer_() IParticipant method
     DDSRECORDER_PARTICIPANTS_DllAPI
     std::shared_ptr<ddspipe::core::IWriter> create_writer(

--- a/ddsrecorder_participants/include/ddsrecorder_participants/replayer/McapReaderParticipant.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/replayer/McapReaderParticipant.hpp
@@ -71,7 +71,7 @@ public:
     bool is_rtps_kind() const noexcept override;
 
     //! Override topic_qos() IParticipant method
-    DDSPIPE_PARTICIPANTS_DllAPI
+    DDSRECORDER_PARTICIPANTS_DllAPI
     ddspipe::core::types::TopicQoS topic_qos() const noexcept override;
 
     //! Override create_writer_() IParticipant method

--- a/ddsrecorder_participants/src/cpp/replayer/McapReaderParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/McapReaderParticipant.cpp
@@ -68,6 +68,11 @@ bool McapReaderParticipant::is_rtps_kind() const noexcept
     return false;
 }
 
+TopicQoS McapReaderParticipant::topic_qos() const noexcept
+{
+    return configuration_->topic_qos;
+}
+
 std::shared_ptr<IWriter> McapReaderParticipant::create_writer(
         const ITopic& /* topic */)
 {

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
@@ -22,6 +22,7 @@
 
 #include <cpp_utils/memory/Heritable.hpp>
 
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
 
@@ -51,6 +52,9 @@ public:
 
     RecorderConfiguration(
             const std::string& file_path);
+
+    // DDS Pipe Configuration
+    ddspipe::core::DdsPipeConfiguration ddspipe_configuration;
 
     // Participants configurations
     std::shared_ptr<ddspipe::participants::SimpleParticipantConfiguration> simple_configuration;

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
@@ -75,8 +75,8 @@ public:
     unsigned int buffer_size = 100;
     unsigned int event_window = 20;
     bool log_publish_time = false;
+    float max_rx_rate = 0;
     unsigned int downsampling = 1;
-    float max_reception_rate = 0;
     bool only_with_type = false;
     mcap::McapWriterOptions mcap_writer_options{"ros2"};
     bool record_types = true;

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
@@ -23,6 +23,7 @@
 #include <cpp_utils/memory/Heritable.hpp>
 
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
 
@@ -85,9 +86,9 @@ public:
 
     // Specs
     unsigned int n_threads = 12;
-    unsigned int max_history_depth = 5000;
     int max_pending_samples = 5000;  // -1 <-> no limit || 0 <-> no pending samples
     unsigned int cleanup_period;
+    ddspipe::core::types::TopicQoS topic_qos{};
 
 protected:
 

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
@@ -60,11 +60,6 @@ public:
     std::shared_ptr<ddspipe::participants::SimpleParticipantConfiguration> simple_configuration;
     std::shared_ptr<ddspipe::participants::ParticipantConfiguration> recorder_configuration;
 
-    // Topic filtering
-    std::set<utils::Heritable<ddspipe::core::types::IFilterTopic>> allowlist{};
-    std::set<utils::Heritable<ddspipe::core::types::IFilterTopic>> blocklist{};
-    std::set<utils::Heritable<ddspipe::core::types::DistributedTopic>> builtin_topics{};
-
     // Output file params
     std::string output_filepath = ".";
     std::string output_filename = "output";

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
@@ -71,8 +71,6 @@ public:
     unsigned int buffer_size = 100;
     unsigned int event_window = 20;
     bool log_publish_time = false;
-    float max_rx_rate = 0;
-    unsigned int downsampling = 1;
     bool only_with_type = false;
     mcap::McapWriterOptions mcap_writer_options{"ros2"};
     bool record_types = true;

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp
@@ -60,11 +60,6 @@ public:
     std::shared_ptr<ddsrecorder::participants::McapReaderParticipantConfiguration> mcap_reader_configuration;
     std::shared_ptr<ddspipe::participants::SimpleParticipantConfiguration> replayer_configuration;
 
-    // Topic filtering
-    std::set<utils::Heritable<ddspipe::core::types::IFilterTopic>> allowlist{};
-    std::set<utils::Heritable<ddspipe::core::types::IFilterTopic>> blocklist{};
-    std::set<utils::Heritable<ddspipe::core::types::DistributedTopic>> builtin_topics{};
-
     // Replay params
     std::string input_file;
     utils::Fuzzy<utils::Timestamp> begin_time{};

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp
@@ -22,6 +22,7 @@
 #include <cpp_utils/time/time_utils.hpp>
 #include <cpp_utils/types/Fuzzy.hpp>
 
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
 
@@ -51,6 +52,9 @@ public:
 
     ReplayerConfiguration(
             const std::string& file_path);
+
+    // DDS Pipe Configuration
+    ddspipe::core::DdsPipeConfiguration ddspipe_configuration;
 
     // Participants configurations
     std::shared_ptr<ddsrecorder::participants::McapReaderParticipantConfiguration> mcap_reader_configuration;

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp
@@ -76,6 +76,7 @@ public:
     // Specs
     unsigned int n_threads = 12;
     unsigned int max_history_depth = 5000;
+    float max_tx_rate = 0;
 
 protected:
 

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp
@@ -23,6 +23,7 @@
 #include <cpp_utils/types/Fuzzy.hpp>
 
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
 
@@ -70,8 +71,7 @@ public:
 
     // Specs
     unsigned int n_threads = 12;
-    unsigned int max_history_depth = 5000;
-    float max_tx_rate = 0;
+    ddspipe::core::types::TopicQoS topic_qos{};
 
 protected:
 

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -199,21 +199,25 @@ void RecorderConfiguration::load_recorder_configuration_(
     }
 
     /////
-    // Get optional downsampling
-    if (YamlReader::is_tag_present(yml, DOWNSAMPLING_TAG))
+    // Get optional max reception rate
+    if (YamlReader::is_tag_present(yml, MAX_RX_RATE_TAG))
     {
-        downsampling = YamlReader::get_positive_int(yml, DOWNSAMPLING_TAG);
-        // Set default value for downsampling
-        TopicQoS::default_downsampling.store(downsampling);
+        // Save max reception rate
+        max_rx_rate = YamlReader::get_nonnegative_float(yml, MAX_RX_RATE_TAG);
+
+        // Set default value for max reception rate
+        TopicQoS::default_max_rx_rate.store(max_rx_rate);
     }
 
     /////
-    // Get optional max reception rate
-    if (YamlReader::is_tag_present(yml, MAX_RECEPTION_RATE_TAG))
+    // Get optional downsampling
+    if (YamlReader::is_tag_present(yml, DOWNSAMPLING_TAG))
     {
-        // Set default value for max reception rate
-        TopicQoS::default_max_reception_rate.store(YamlReader::get_nonnegative_float(yml,
-                MAX_RECEPTION_RATE_TAG));
+        // Save downsampling factor
+        downsampling = YamlReader::get_positive_int(yml, DOWNSAMPLING_TAG);
+
+        // Set default value for downsampling
+        TopicQoS::default_downsampling.store(downsampling);
     }
 
     /////

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -384,6 +384,19 @@ void RecorderConfiguration::load_dds_configuration_(
     }
 
     /////
+    // Get optional topics
+    if (YamlReader::is_tag_present(yml, TOPICS_TAG))
+    {
+        auto manual_topics = YamlReader::get_list<WildcardDdsFilterTopic>(yml, TOPICS_TAG, version);
+
+        for (auto const& manual_topic : manual_topics)
+        {
+            auto new_topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable(manual_topic);
+            ddspipe_configuration.manual_topics.push_back(new_topic);
+        }
+    }
+
+    /////
     // Get optional builtin topics
     if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
     {

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -20,6 +20,7 @@
 #include <cpp_utils/utils.hpp>
 
 #include <ddspipe_core/types/dynamic_types/types.hpp>
+#include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 #include <ddspipe_participants/types/address/Address.hpp>
 
@@ -370,13 +371,9 @@ void RecorderConfiguration::load_dds_configuration_(
     // Get optional topics
     if (YamlReader::is_tag_present(yml, TOPICS_TAG))
     {
-        auto manual_topics = YamlReader::get_list<WildcardDdsFilterTopic>(yml, TOPICS_TAG, version);
-
-        for (auto const& manual_topic : manual_topics)
-        {
-            auto new_topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable(manual_topic);
-            ddspipe_configuration.manual_topics.push_back(new_topic);
-        }
+        const auto& manual_topics = YamlReader::get_list<ManualTopic>(yml, TOPICS_TAG, version);
+        ddspipe_configuration.manual_topics =
+                std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
     }
 
     /////

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -204,28 +204,6 @@ void RecorderConfiguration::load_recorder_configuration_(
     }
 
     /////
-    // Get optional max reception rate
-    if (YamlReader::is_tag_present(yml, MAX_RX_RATE_TAG))
-    {
-        // Save max reception rate
-        max_rx_rate = YamlReader::get_nonnegative_float(yml, MAX_RX_RATE_TAG);
-
-        // Set default value for max reception rate
-        TopicQoS::default_max_rx_rate.store(max_rx_rate);
-    }
-
-    /////
-    // Get optional downsampling
-    if (YamlReader::is_tag_present(yml, DOWNSAMPLING_TAG))
-    {
-        // Save downsampling factor
-        downsampling = YamlReader::get_positive_int(yml, DOWNSAMPLING_TAG);
-
-        // Set default value for downsampling
-        TopicQoS::default_downsampling.store(downsampling);
-    }
-
-    /////
     // Get optional only_with_type
     if (YamlReader::is_tag_present(yml, RECORDER_ONLY_WITH_TYPE_TAG))
     {
@@ -299,12 +277,12 @@ void RecorderConfiguration::load_specs_configuration_(
         n_threads = YamlReader::get_positive_int(yml, NUMBER_THREADS_TAG);
     }
 
-    // Get maximum history depth
-    if (YamlReader::is_tag_present(yml, MAX_HISTORY_DEPTH_TAG))
+    /////
+    // Get optional Topic QoS
+    if (YamlReader::is_tag_present(yml, SPECS_QOS_TAG))
     {
-        max_history_depth = YamlReader::get_positive_int(yml, MAX_HISTORY_DEPTH_TAG);
-        // Set default value for history
-        TopicQoS::default_history_depth.store(max_history_depth);
+        YamlReader::fill<TopicQoS>(topic_qos, YamlReader::get_value_in_tag(yml, SPECS_QOS_TAG), version);
+        TopicQoS::default_topic_qos.set_value(topic_qos);
     }
 
     // Get max pending samples

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -115,10 +115,15 @@ void RecorderConfiguration::load_ddsrecorder_configuration_(
         WildcardDdsFilterTopic rpc_request_topic, rpc_response_topic;
         rpc_request_topic.topic_name.set_value("rq/*");
         rpc_response_topic.topic_name.set_value("rr/*");
-        blocklist.insert(
+
+        ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_request_topic));
-        blocklist.insert(
+
+        ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
+
+        // The DDS Pipe should be enabled on start up.
+        ddspipe_configuration.init_enabled = true;
 
         // Initialize controller domain with the same as the one being recorded
         // WARNING: dds tag must have been parsed beforehand
@@ -367,12 +372,12 @@ void RecorderConfiguration::load_dds_configuration_(
     // Get optional allowlist
     if (YamlReader::is_tag_present(yml, ALLOWLIST_TAG))
     {
-        allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG, version);
+        ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG, version);
 
         // Add to allowlist always the type object topic
         WildcardDdsFilterTopic internal_topic;
         internal_topic.topic_name.set_value(TYPE_OBJECT_TOPIC_NAME);
-        allowlist.insert(
+        ddspipe_configuration.allowlist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(internal_topic));
     }
 
@@ -380,7 +385,7 @@ void RecorderConfiguration::load_dds_configuration_(
     // Get optional blocklist
     if (YamlReader::is_tag_present(yml, BLOCKLIST_TAG))
     {
-        blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG, version);
+        ddspipe_configuration.blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG, version);
     }
 
     /////
@@ -401,7 +406,7 @@ void RecorderConfiguration::load_dds_configuration_(
     if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
     {
         // WARNING: Parse builtin topics AFTER specs and recorder, as some topic-specific default values are set there
-        builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
+        ddspipe_configuration.builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
                         version);
     }
 }

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -351,7 +351,8 @@ void RecorderConfiguration::load_dds_configuration_(
     // Get optional allowlist
     if (YamlReader::is_tag_present(yml, ALLOWLIST_TAG))
     {
-        ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG, version);
+        ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG,
+                        version);
 
         // Add to allowlist always the type object topic
         WildcardDdsFilterTopic internal_topic;
@@ -364,7 +365,8 @@ void RecorderConfiguration::load_dds_configuration_(
     // Get optional blocklist
     if (YamlReader::is_tag_present(yml, BLOCKLIST_TAG))
     {
-        ddspipe_configuration.blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG, version);
+        ddspipe_configuration.blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG,
+                        version);
     }
 
     /////

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -174,6 +174,17 @@ void ReplayerConfiguration::load_replay_configuration_(
         start_replay_time = YamlReader::get<utils::Timestamp>(yml, REPLAYER_REPLAY_START_TIME_TAG, version);
     }
 
+    /////
+    // Get optional max transmission rate
+    if (YamlReader::is_tag_present(yml, MAX_TX_RATE_TAG))
+    {
+        // Save max transmission rate
+        max_tx_rate = YamlReader::get_nonnegative_float(yml, MAX_TX_RATE_TAG);
+
+        // Set default value for max transmission rate
+        TopicQoS::default_max_tx_rate.store(max_tx_rate);
+    }
+
     // Get optional replay_types
     if (YamlReader::is_tag_present(yml, REPLAYER_REPLAY_TYPES_TAG))
     {

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -120,10 +120,15 @@ void ReplayerConfiguration::load_ddsreplayer_configuration_(
         WildcardDdsFilterTopic rpc_request_topic, rpc_response_topic;
         rpc_request_topic.topic_name.set_value("rq/*");
         rpc_response_topic.topic_name.set_value("rr/*");
-        blocklist.insert(
+
+        ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_request_topic));
-        blocklist.insert(
+
+        ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
+
+        // The DDS Pipe should be enabled on start up.
+        ddspipe_configuration.init_enabled = true;
     }
     catch (const std::exception& e)
     {
@@ -264,12 +269,12 @@ void ReplayerConfiguration::load_dds_configuration_(
     // Get optional allowlist
     if (YamlReader::is_tag_present(yml, ALLOWLIST_TAG))
     {
-        allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG, version);
+        ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG, version);
 
         // Add to allowlist always the type object topic
         WildcardDdsFilterTopic internal_topic;
         internal_topic.topic_name.set_value(TYPE_OBJECT_TOPIC_NAME);
-        allowlist.insert(
+        ddspipe_configuration.allowlist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(internal_topic));
     }
 
@@ -277,7 +282,7 @@ void ReplayerConfiguration::load_dds_configuration_(
     // Get optional blocklist
     if (YamlReader::is_tag_present(yml, BLOCKLIST_TAG))
     {
-        blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG, version);
+        ddspipe_configuration.blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG, version);
     }
 
     /////
@@ -298,7 +303,7 @@ void ReplayerConfiguration::load_dds_configuration_(
     if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
     {
         // WARNING: Parse builtin topics AFTER specs, as some topic-specific default values are set there
-        builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
+        ddspipe_configuration.builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
                         version);
     }
 }

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -74,7 +74,6 @@ void ReplayerConfiguration::load_ddsreplayer_configuration_(
 
         /////
         // Get optional specs configuration
-        // WARNING: Parse builtin topics (dds tag) AFTER specs, as some topic-specific default values are set there
         if (YamlReader::is_tag_present(yml, SPECS_TAG))
         {
             auto specs_yml = YamlReader::get_value_in_tag(yml, SPECS_TAG);
@@ -282,15 +281,6 @@ void ReplayerConfiguration::load_dds_configuration_(
         const auto& manual_topics = YamlReader::get_list<ManualTopic>(yml, TOPICS_TAG, version);
         ddspipe_configuration.manual_topics =
                 std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
-    }
-
-    /////
-    // Get optional builtin topics
-    if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
-    {
-        // WARNING: Parse builtin topics AFTER specs, as some topic-specific default values are set there
-        ddspipe_configuration.builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
-                        version);
     }
 }
 

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -179,17 +179,6 @@ void ReplayerConfiguration::load_replay_configuration_(
         start_replay_time = YamlReader::get<utils::Timestamp>(yml, REPLAYER_REPLAY_START_TIME_TAG, version);
     }
 
-    /////
-    // Get optional max transmission rate
-    if (YamlReader::is_tag_present(yml, MAX_TX_RATE_TAG))
-    {
-        // Save max transmission rate
-        max_tx_rate = YamlReader::get_nonnegative_float(yml, MAX_TX_RATE_TAG);
-
-        // Set default value for max transmission rate
-        TopicQoS::default_max_tx_rate.store(max_tx_rate);
-    }
-
     // Get optional replay_types
     if (YamlReader::is_tag_present(yml, REPLAYER_REPLAY_TYPES_TAG))
     {
@@ -207,12 +196,12 @@ void ReplayerConfiguration::load_specs_configuration_(
         n_threads = YamlReader::get_positive_int(yml, NUMBER_THREADS_TAG);
     }
 
-    // Get maximum history depth
-    if (YamlReader::is_tag_present(yml, MAX_HISTORY_DEPTH_TAG))
+    /////
+    // Get optional Topic QoS
+    if (YamlReader::is_tag_present(yml, SPECS_QOS_TAG))
     {
-        max_history_depth = YamlReader::get_positive_int(yml, MAX_HISTORY_DEPTH_TAG);
-        // Set default value for history
-        TopicQoS::default_history_depth.store(max_history_depth);
+        YamlReader::fill<TopicQoS>(topic_qos, YamlReader::get_value_in_tag(yml, SPECS_QOS_TAG), version);
+        TopicQoS::default_topic_qos.set_value(topic_qos);
     }
 
     // Get wait all acknowledged timeout

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -20,6 +20,7 @@
 #include <cpp_utils/utils.hpp>
 
 #include <ddspipe_core/types/dynamic_types/types.hpp>
+#include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 #include <ddspipe_participants/writer/rtps/CommonWriter.hpp>
@@ -278,13 +279,9 @@ void ReplayerConfiguration::load_dds_configuration_(
     // Get optional topics
     if (YamlReader::is_tag_present(yml, TOPICS_TAG))
     {
-        auto manual_topics = YamlReader::get_list<WildcardDdsFilterTopic>(yml, TOPICS_TAG, version);
-
-        for (auto const& manual_topic : manual_topics)
-        {
-            auto new_topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable(manual_topic);
-            ddspipe_configuration.manual_topics.push_back(new_topic);
-        }
+        const auto& manual_topics = YamlReader::get_list<ManualTopic>(yml, TOPICS_TAG, version);
+        ddspipe_configuration.manual_topics =
+                std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
     }
 
     /////

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -258,7 +258,8 @@ void ReplayerConfiguration::load_dds_configuration_(
     // Get optional allowlist
     if (YamlReader::is_tag_present(yml, ALLOWLIST_TAG))
     {
-        ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG, version);
+        ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG,
+                        version);
 
         // Add to allowlist always the type object topic
         WildcardDdsFilterTopic internal_topic;
@@ -271,7 +272,8 @@ void ReplayerConfiguration::load_dds_configuration_(
     // Get optional blocklist
     if (YamlReader::is_tag_present(yml, BLOCKLIST_TAG))
     {
-        ddspipe_configuration.blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG, version);
+        ddspipe_configuration.blocklist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, BLOCKLIST_TAG,
+                        version);
     }
 
     /////

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -281,6 +281,19 @@ void ReplayerConfiguration::load_dds_configuration_(
     }
 
     /////
+    // Get optional topics
+    if (YamlReader::is_tag_present(yml, TOPICS_TAG))
+    {
+        auto manual_topics = YamlReader::get_list<WildcardDdsFilterTopic>(yml, TOPICS_TAG, version);
+
+        for (auto const& manual_topic : manual_topics)
+        {
+            auto new_topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable(manual_topic);
+            ddspipe_configuration.manual_topics.push_back(new_topic);
+        }
+    }
+
+    /////
     // Get optional builtin topics
     if (YamlReader::is_tag_present(yml, BUILTIN_TAG))
     {

--- a/ddsreplayer/src/cpp/main.cpp
+++ b/ddsreplayer/src/cpp/main.cpp
@@ -58,11 +58,7 @@ std::unique_ptr<eprosima::utils::event::FileWatcherHandler> create_filewatcher(
                 try
                 {
                     eprosima::ddsrecorder::yaml::ReplayerConfiguration new_configuration(file_path);
-                    // Create new allowed topics list
-                    auto new_allowed_topics = std::make_shared<core::AllowedTopicList>(
-                        new_configuration.allowlist,
-                        new_configuration.blocklist);
-                    replayer->reload_allowed_topics(new_allowed_topics);
+                    replayer->reload_configuration(new_configuration);
                 }
                 catch (const std::exception& e)
                 {
@@ -93,11 +89,7 @@ std::unique_ptr<eprosima::utils::event::PeriodicEventHandler> create_periodic_ha
                 try
                 {
                     eprosima::ddsrecorder::yaml::ReplayerConfiguration new_configuration(file_path);
-                    // Create new allowed topics list
-                    auto new_allowed_topics = std::make_shared<core::AllowedTopicList>(
-                        new_configuration.allowlist,
-                        new_configuration.blocklist);
-                    replayer->reload_allowed_topics(new_allowed_topics);
+                    replayer->reload_configuration(new_configuration);
                 }
                 catch (const std::exception& e)
                 {

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -134,7 +134,10 @@ DdsReplayer::DdsReplayer(
     auto builtin_topics = generate_builtin_topics_(configuration, input_file);
 
     // Create DDS Pipe
+    DdsPipeConfiguration ddspipe_configuration;
+
     pipe_ = std::make_unique<DdsPipe>(
+        ddspipe_configuration,
         allowed_topics,
         discovery_database_,
         payload_pool_,

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -291,7 +291,7 @@ std::set<utils::Heritable<DistributedTopic>> DdsReplayer::generate_builtin_topic
             utils::Heritable<DistributedTopic> topic = channel_topic->copy();
 
             // Apply the Manual Topics for this participant.
-            for (const auto& manual_topic : configuration.ddspipe_configuration.get_manual_topics(channel_topic))
+            for (const auto& manual_topic : configuration.ddspipe_configuration.get_manual_topics(*channel_topic))
             {
                 topic->topic_qos.set_qos(manual_topic.first->topic_qos, utils::FuzzyLevelValues::fuzzy_level_hard);
             }

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -279,8 +279,8 @@ std::set<utils::Heritable<DistributedTopic>> DdsReplayer::generate_builtin_topic
 
         // Apply the QoS stored in the MCAP file as if they were the discovered QoS.
         channel_topic->topic_qos.set_qos(
-                deserialize_qos_(it->second->metadata[QOS_SERIALIZATION_QOS]),
-                utils::FuzzyLevelValues::fuzzy_level_fuzzy);
+            deserialize_qos_(it->second->metadata[QOS_SERIALIZATION_QOS]),
+            utils::FuzzyLevelValues::fuzzy_level_fuzzy);
 
         // Insert channel topic in builtin topics list
         builtin_topics.insert(channel_topic);

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -134,10 +134,8 @@ DdsReplayer::DdsReplayer(
     auto builtin_topics = generate_builtin_topics_(configuration, input_file);
 
     // Create DDS Pipe
-    DdsPipeConfiguration ddspipe_configuration;
-
     pipe_ = std::make_unique<DdsPipe>(
-        ddspipe_configuration,
+        configuration.ddspipe_configuration,
         allowed_topics,
         discovery_database_,
         payload_pool_,

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -287,8 +287,18 @@ std::set<utils::Heritable<DistributedTopic>> DdsReplayer::generate_builtin_topic
 
         if (configuration.replay_types && registered_types.count(type_name) != 0)
         {
+            // Make a copy of the Topic to customize it according to the Participant's configured QoS.
+            utils::Heritable<DistributedTopic> topic = channel_topic->copy();
+
+            // Apply the Manual Topics for this participant.
+            for (const auto& manual_topic : configuration.ddspipe_configuration.get_manual_topics(channel_topic))
+            {
+                topic->topic_qos.set_qos(manual_topic.first->topic_qos, utils::FuzzyLevelValues::fuzzy_level_hard);
+            }
+
             // Create Datawriter in this topic so dynamic type can be shared in EDP
-            create_dynamic_writer_(channel_topic);
+            // TODO: Avoid creating the dynamic writer when the topic is not allowed.
+            create_dynamic_writer_(topic);
         }
     }
 

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.hpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.hpp
@@ -61,7 +61,7 @@ public:
      * @throw utils::InitializationException if failed to create dynamic participant/publisher.
      */
     DdsReplayer(
-            const yaml::ReplayerConfiguration& configuration,
+            yaml::ReplayerConfiguration& configuration,
             std::string& input_file);
 
     /**
@@ -79,8 +79,8 @@ public:
      * @return \c RETCODE_OK if allowed topics list has been updated correctly
      * @return \c RETCODE_NO_DATA if new allowed topics list is the same as the previous one
      */
-    utils::ReturnCode reload_allowed_topics(
-            const std::shared_ptr<ddspipe::core::AllowedTopicList>& allowed_topics);
+    utils::ReturnCode reload_configuration(
+            const yaml::ReplayerConfiguration& new_configuration);
 
     //! Process input MCAP file
     void process_mcap();

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: "/dds/topic"
     type: "HelloWorld"
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: "/dds/topic"
-    type: "HelloWorld"
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file.yaml
@@ -1,5 +1,6 @@
 topics:
   - name: /dds/topic
+    type: HelloWorld
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: /dds/topic
     type: HelloWorld
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: /dds/topic
-    type: HelloWorld
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time.yaml
@@ -1,5 +1,6 @@
 topics:
   - name: /dds/topic
+    type: HelloWorld
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time_with_types.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time_with_types.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: /dds/topic
     type: HelloWorld
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time_with_types.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time_with_types.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: /dds/topic
-    type: HelloWorld
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time_with_types.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_begin_time_with_types.yaml
@@ -1,5 +1,6 @@
 topics:
   - name: /dds/topic
+    type: HelloWorld
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: /dds/topic
     type: HelloWorld
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: /dds/topic
-    type: HelloWorld
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time.yaml
@@ -1,5 +1,6 @@
 topics:
   - name: /dds/topic
+    type: HelloWorld
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time_with_types.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time_with_types.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: /dds/topic
     type: HelloWorld
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time_with_types.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_end_time_with_types.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: /dds/topic
-    type: HelloWorld
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_less_hz.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_less_hz.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: /dds/topic
     type: HelloWorld
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_less_hz.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_less_hz.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: /dds/topic
-    type: HelloWorld
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_less_hz.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_less_hz.yaml
@@ -1,5 +1,6 @@
 topics:
   - name: /dds/topic
+    type: HelloWorld
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_more_hz.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_more_hz.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: /dds/topic
     type: HelloWorld
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_more_hz.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_more_hz.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: /dds/topic
-    type: HelloWorld
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_more_hz.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_more_hz.yaml
@@ -1,5 +1,6 @@
 topics:
   - name: /dds/topic
+    type: HelloWorld
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: /dds/topic
     type: HelloWorld
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: /dds/topic
-    type: HelloWorld
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier.yaml
@@ -1,5 +1,6 @@
 topics:
   - name: /dds/topic
+    type: HelloWorld
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier_with_types.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier_with_types.yaml
@@ -1,6 +1,9 @@
 builtin-topics:
   - name: /dds/topic
     type: HelloWorld
+
+topics:
+  - name: /dds/topic
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier_with_types.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier_with_types.yaml
@@ -1,7 +1,3 @@
-builtin-topics:
-  - name: /dds/topic
-    type: HelloWorld
-
 topics:
   - name: /dds/topic
     qos:

--- a/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier_with_types.yaml
+++ b/ddsreplayer/test/blackbox/mcap/resources/config_file_start_replay_time_earlier_with_types.yaml
@@ -1,5 +1,6 @@
 topics:
   - name: /dds/topic
+    type: HelloWorld
     qos:
       reliability: true       # Use QoS RELIABLE
 

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -25,10 +25,11 @@ Next release will include the following **DDS Recorder tool configuration featur
 * Support :ref:`Compression Settings <recorder_usage_configuration_compression>`.
 * Allow disabling the storage of received types (see :ref:`Record Types <recorder_usage_configuration_recordtypes>`).
 * New configuration options (``timestamp-format`` and ``local-timestamp``) available for :ref:`output file <recorder_usage_configuration_outputfile>` settings.
-* New configuration option (``max-tx-rate``) to configure the :ref:`Max transmission rate <replayer_usage_configuration_max_tx_rate>`).
-* New configuration option (``topics``) to configure the :ref:`Manual Topics <recorder_manual_topics>`).
+* New configuration option (``topics``) to configure the :ref:`Manual Topics <recorder_manual_topics>`.
 * Rename ``max-reception-rate`` to ``max-rx-rate``.
 
 Next release will include the following **DDS Replayer tool configuration features**:
 
-* Remove the support for :ref:`Built-in Topics <recorder_builtin_topics>`.
+* New configuration option (``topics``) to configure the :ref:`Manual Topics <replayer_manual_topics>`.
+* New configuration option (``max-tx-rate``) to configure the :ref:`Max transmission rate <replayer_usage_configuration_max_tx_rate>`.
+* Remove the support for `Built-in Topics <https://dds-recorder.readthedocs.io/en/v0.2.0/rst/replaying/usage/configuration.html#built-in-topics>`_.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -25,4 +25,5 @@ Next release will include the following **DDS Recorder tool configuration featur
 * Support :ref:`Compression Settings <recorder_usage_configuration_compression>`.
 * Allow disabling the storage of received types (see :ref:`Record Types <recorder_usage_configuration_recordtypes>`).
 * New configuration options (``timestamp-format`` and ``local-timestamp``) available for :ref:`output file <recorder_usage_configuration_outputfile>` settings.
+* New configuration option (``max-tx-rate``) to configure the :ref:`Max transmission rate <replayer_usage_configuration_max_tx_rate>`).
 * Rename ``max-reception-rate`` to ``max-rx-rate``.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -26,4 +26,5 @@ Next release will include the following **DDS Recorder tool configuration featur
 * Allow disabling the storage of received types (see :ref:`Record Types <recorder_usage_configuration_recordtypes>`).
 * New configuration options (``timestamp-format`` and ``local-timestamp``) available for :ref:`output file <recorder_usage_configuration_outputfile>` settings.
 * New configuration option (``max-tx-rate``) to configure the :ref:`Max transmission rate <replayer_usage_configuration_max_tx_rate>`).
+* New configuration option (``topics``) to configure the :ref:`Topics <recorder_manual_topics>`).
 * Rename ``max-reception-rate`` to ``max-rx-rate``.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -25,3 +25,4 @@ Next release will include the following **DDS Recorder tool configuration featur
 * Support :ref:`Compression Settings <recorder_usage_configuration_compression>`.
 * Allow disabling the storage of received types (see :ref:`Record Types <recorder_usage_configuration_recordtypes>`).
 * New configuration options (``timestamp-format`` and ``local-timestamp``) available for :ref:`output file <recorder_usage_configuration_outputfile>` settings.
+* Rename ``max-reception-rate`` to ``max-rx-rate``.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -26,5 +26,5 @@ Next release will include the following **DDS Recorder tool configuration featur
 * Allow disabling the storage of received types (see :ref:`Record Types <recorder_usage_configuration_recordtypes>`).
 * New configuration options (``timestamp-format`` and ``local-timestamp``) available for :ref:`output file <recorder_usage_configuration_outputfile>` settings.
 * New configuration option (``max-tx-rate``) to configure the :ref:`Max transmission rate <replayer_usage_configuration_max_tx_rate>`).
-* New configuration option (``topics``) to configure the :ref:`Topics <recorder_manual_topics>`).
+* New configuration option (``topics``) to configure the :ref:`Manual Topics <recorder_manual_topics>`).
 * Rename ``max-reception-rate`` to ``max-rx-rate``.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -28,3 +28,7 @@ Next release will include the following **DDS Recorder tool configuration featur
 * New configuration option (``max-tx-rate``) to configure the :ref:`Max transmission rate <replayer_usage_configuration_max_tx_rate>`).
 * New configuration option (``topics``) to configure the :ref:`Manual Topics <recorder_manual_topics>`).
 * Rename ``max-reception-rate`` to ``max-rx-rate``.
+
+Next release will include the following **DDS Replayer tool configuration features**:
+
+* Remove the support for :ref:`Built-in Topics <recorder_builtin_topics>`.

--- a/docs/rst/recording/remote_control/remote_control.rst
+++ b/docs/rst/recording/remote_control/remote_control.rst
@@ -60,7 +60,7 @@ Therefore, any user can create his own application to control the |ddsrecorder| 
 .. note::
 
     Status and command topics are not blocked by default, i.e. messages on this topics will be recorded if listening on the same domain the controller is launched.
-    If willing to avoid this, include these topics in the :ref:`blocklist <recorder_topic_filtering_blocklist>`:
+    If willing to avoid this, include these topics in the :ref:`blocklist <recorder_topic_filtering>`:
 
     .. code-block:: yaml
 

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -163,7 +163,8 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
 
 .. warning::
 
-    The ``TRANSIENT_LOCAL`` durability is not compatible with the ``BEST_EFFORT`` reliability.
+    Manually configuring ``TRANSIENT_LOCAL`` durability may lead to incompatibility issues when the discovered reliability is ``BEST_EFFORT``.
+    Please ensure to always configure the ``reliability`` when configuring the ``durability`` to avoid the issue.
 
 .. _recorder_history_depth:
 

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -186,7 +186,13 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
         - ``keyed``
         - *bool*
         - ``false``
-        - Topic with / without key
+        - Topic with / without `key <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/topic/typeSupport/typeSupport.html#data-types-with-a-key>`_
+
+    *   - History Depth
+        - ``history-depth``
+        - *integer*
+        - ``5000``
+        - :ref:`recorder_history_depth`
 
     *   - Max Reception Rate
         - ``max-rx-rate``
@@ -200,24 +206,34 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
         - ``1``
         - :ref:`recorder_downsampling`
 
+.. _recorder_history_depth:
+
+History Depth
+"""""""""""""
+
+The ``history-depth`` tag configures the history depth of the Fast DDS internal entities.
+By default, the depth of every RTPS History instance is :code:`5000`, which sets a constraint on the maximum number of samples a |ddsrecorder| instance can deliver to late joiner Readers configured with ``TRANSIENT_LOCAL`` `DurabilityQosPolicyKind <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/standardQosPolicies.html#durabilityqospolicykind>`_.
+Its value should be decreased when the sample size and/or number of created endpoints (increasing with the number of topics) are big enough to cause memory exhaustion issues.
+If enough memory is available, however, the ``history-depth`` could be increased to deliver a greater number of samples to late joiners.
+
 .. _recorder_max_rx_rate:
 
 Max Reception Rate
 """"""""""""""""""
 
-Limits the frequency [Hz] at which samples are processed, by discarding messages received before :code:`1/max-rx-rate` seconds have elapsed since the last processed message was received.
-When specified, ``max-rx-rate`` is set for all topics without distinction, but a different value can also set for a particular topic under the ``qos`` configuration tag within the builtin-topics list.
-This parameter only accepts non-negative values, and its default value is ``0`` (no limit).
+The ``max-rx-rate`` tag limits the frequency [Hz] at which samples are processed by discarding messages received before :code:`1/max-rx-rate` seconds have passed since the last processed message.
+It only accepts non-negative numbers.
+By default it is set to ``0``; it processes samples at an unlimited reception rate.
 
 .. _recorder_downsampling:
 
 Downsampling
 """"""""""""
 
-Reduces the sampling rate of the received data by keeping *1* out of every *n* samples received (per topic), where *n* is the value specified in ``downsampling``.
-If ``max-rx-rate`` is also set, downsampling applies to messages that already managed to pass this filter.
-When specified, this downsampling factor is set for all topics without distinction, but a different value can also set for a particular topic under the ``qos`` configuration tag within the builtin-topics list.
-This parameter only accepts positive integer values, and its default value is ``1`` (no downsampling).
+The ``downsampling`` tag reduces the sampling rate of the received data by only keeping *1* out of every *n* samples received (per topic), where *n* is the value specified under the ``downsampling`` tag.
+When the ``max-rx-rate`` tag is also set, down-sampling only applies to messages that have passed the ``max-rx-rate`` filter.
+It only accepts positive integers.
+By default it is set to ``1``; it accepts every message.
 
 .. _recorder_manual_topics:
 
@@ -571,6 +587,11 @@ Cleanup Period
 As explained in :ref:`Event Window <recorder_usage_configuration_event_window>`, a |ddsrecorder| in paused mode awaits for an event command to write in disk all samples received in the last ``event-window`` seconds.
 To accomplish this, received samples are stored in memory until the aforementioned event is triggered and, in order to limit memory consumption, outdated (received more than ``event-window`` seconds ago) samples are removed from this buffer every ``cleanup-period`` seconds.
 By default, its value is equal to twice the ``event-window``.
+
+QoS
+^^^
+
+``specs`` supports a ``qos`` **optional** tag to configure the default values of the :ref:`Topic QoS <recorder_topic_qos>`.
 
 .. _recorder_usage_configuration_general_example:
 

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -122,20 +122,8 @@ If a topic matches an expression both in the ``allowlist`` and in the ``blocklis
           - name: "*"
             type: HelloWorld
 
-.. _recorder_builtin_topics:
-
-Built-in Topics
-^^^^^^^^^^^^^^^
-
-Apart from the dynamic DDS topics discovered in the network, the discovery phase can be accelerated by using the builtin topic list (``builtin-topics``).
-By defining topics in this list, the |ddsrecorder| will create the DataWriters and DataReaders in recorder initialization.
-
-The builtin-topics list is defined in the same form as the ``allowlist`` and ``blocklist``.
-
-This feature also allows to manually force the QoS of a specific topic, so the entities created in such topic follows the specified QoS and not the one first discovered.
-
 Topic Quality of Service
-""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 For every topic contained in this list, both ``name`` and ``type`` must be specified and contain no wildcard characters.
 Apart from these values, the tag ``qos`` under each topic allows to configure the following values:
@@ -196,6 +184,39 @@ Apart from these values, the tag ``qos`` under each topic allows to configure th
         - *integer*
         - *default value*
         - Downsampling factor
+
+.. _recorder_manual_topics:
+
+Topics
+^^^^^^
+
+A subset of QoSs can be manually configured for a specific topic under the tag ``topics``.
+The tag ``topics`` has a required ``name`` tag that accepts wildcard characters.
+It also has two optional tags: a ``type`` tag that accepts wildcard characters, and a ``qos`` tag with the QoSs that the user wants to manually configure.
+If a ``qos`` is not manually configured, it will get its value by discovery.
+
+**Example of usage**
+
+.. code-block:: yaml
+
+    topics:
+      - name: temperature/*
+        type: temperature/types/*
+        qos:
+            max-rx-rate: 15
+            downsampling: 2
+
+.. _recorder_builtin_topics:
+
+Built-in Topics
+^^^^^^^^^^^^^^^
+
+Apart from the dynamic DDS topics discovered in the network, the discovery phase can be accelerated by using the builtin topic list (``builtin-topics``).
+By defining topics in this list, the |ddsrecorder| will create the DataWriters and DataReaders in recorder initialization.
+
+The builtin-topics list is defined in the same form as the ``allowlist`` and ``blocklist``.
+
+This feature also allows to manually force the QoS of a specific topic, so the entities created in such topic follows the specified QoS and not the one first discovered.
 
 **Example of usage:**
 
@@ -585,6 +606,13 @@ A complete example of all the configurations described on this page can be found
       blocklist:
         - name: "topic_name"
           type: "topic_type"
+
+      topics:
+        - name: temperature/*
+          type: temperature/types/*
+          qos:
+            max-rx-rate: 15
+            downsampling: 2
 
       builtin-topics:
         - name: "HelloWorldTopic"

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -59,11 +59,6 @@ Topic Filtering
 
 The |ddsrecorder| automatically detects the topics that are being used in a DDS Network.
 The |ddsrecorder| then creates internal DDS :term:`Readers<DataReader>` to record the data published on each topic.
-
-.. note::
-
-    |ddsrecorder| entities are created with the :ref:`Topic QoS <recorder_topic_qos>` of the first Subscriber found on the Topic.
-
 The |ddsrecorder| allows filtering DDS :term:`Topics<Topic>` to allow users to configure the DDS :term:`Topics<Topic>` that must be recorded.
 These data filtering rules can be configured under the ``allowlist`` and ``blocklist`` tags.
 If the ``allowlist`` and ``blocklist`` are not configured, the |ddsrecorder| will recorded the data published on every topic it discovers.

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -185,17 +185,17 @@ Apart from these values, the tag ``qos`` under each topic allows to configure th
         - ``false``
         - Topic with / without key
 
+    *   - Max Reception Rate
+        - ``max-rx-rate``
+        - *float*
+        - *default value*
+        - Maximum sample reception rate [Hz]
+
     *   - Downsampling
         - ``downsampling``
         - *integer*
         - *default value*
         - Downsampling factor
-
-    *   - Max Reception Rate
-        - ``max-reception-rate``
-        - *float*
-        - *default value*
-        - Maximum sample reception rate [Hz]
 
 **Example of usage:**
 
@@ -211,8 +211,8 @@ Apart from these values, the tag ``qos`` under each topic allows to configure th
               partitions: true        # Topic with partitions
               ownership: false        # Use QoS SHARED_OWNERSHIP_QOS
               keyed: true             # Topic with key
+              max-rx-rate: 10         # Discard messages if less than 100ms elapsed since the last sample was processed
               downsampling: 4         # Keep 1 of every 4 samples
-              max-reception-rate: 10  # Discard messages if less than 100ms elapsed since the last sample was processed
 
 
 .. _recorder_usage_configuration_domain_id:
@@ -374,15 +374,15 @@ In some applications, it may be required to use the ``publishTime`` as ``logTime
 Max Reception Rate
 ^^^^^^^^^^^^^^^^^^
 
-Limits the frequency [Hz] at which samples are processed, by discarding messages received before :code:`1/max-reception-rate` seconds have elapsed since the last processed message was received.
-When specified, ``max-reception-rate`` is set for all topics without distinction, but a different value can also set for a particular topic under the ``qos`` configuration tag within the builtin-topics list.
+Limits the frequency [Hz] at which samples are processed, by discarding messages received before :code:`1/max-rx-rate` seconds have elapsed since the last processed message was received.
+When specified, ``max-rx-rate`` is set for all topics without distinction, but a different value can also set for a particular topic under the ``qos`` configuration tag within the builtin-topics list.
 This parameter only accepts non-negative values, and its default value is ``0`` (no limit).
 
 Downsampling
 ^^^^^^^^^^^^
 
 Reduces the sampling rate of the received data by keeping *1* out of every *n* samples received (per topic), where *n* is the value specified in ``downsampling``.
-If ``max-reception-rate`` is also set, downsampling applies to messages that already managed to pass this filter.
+If ``max-rx-rate`` is also set, downsampling applies to messages that already managed to pass this filter.
 When specified, this downsampling factor is set for all topics without distinction, but a different value can also set for a particular topic under the ``qos`` configuration tag within the builtin-topics list.
 This parameter only accepts positive integer values, and its default value is ``1`` (no downsampling).
 
@@ -595,8 +595,8 @@ A complete example of all the configurations described on this page can be found
             keyed: false
             partitions: true
             ownership: false
+            max-rx-rate: 10
             downsampling: 4
-            max-reception-rate: 10
 
       ignore-participant-flags: no_filter
       transport: builtin
@@ -613,8 +613,8 @@ A complete example of all the configurations described on this page can be found
       buffer-size: 50
       event-window: 60
       log-publish-time: false
+      max-rx-rate: 20
       downsampling: 3
-      max-reception-rate: 20
       only-with-type: false
       compression:
         algorithm: lz4

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -250,11 +250,11 @@ If a ``qos`` is not manually configured, it will get its value by discovery.
 .. code-block:: yaml
 
     topics:
-      - name: temperature/*
-        type: temperature/types/*
+      - name: "temperature/*"
+        type: "temperature/types/*"
         qos:
-            max-rx-rate: 15
-            downsampling: 2
+          max-rx-rate: 15
+          downsampling: 2
 
 .. _recorder_usage_configuration_domain_id:
 
@@ -622,8 +622,8 @@ A complete example of all the configurations described on this page can be found
           type: "HelloWorld"
 
       topics:
-        - name: temperature/*
-          type: temperature/types/*
+        - name: "temperature/*"
+          type: "temperature/types/*"
           qos:
             max-rx-rate: 15
             downsampling: 2

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -161,6 +161,10 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
         - ``1``
         - :ref:`recorder_downsampling`
 
+.. warning::
+
+    The ``TRANSIENT_LOCAL`` durability is not compatible with the ``BEST_EFFORT`` reliability.
+
 .. _recorder_history_depth:
 
 History Depth

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -64,7 +64,7 @@ The |ddsrecorder| then creates internal DDS :term:`Readers<DataReader>` to recor
 
     |ddsrecorder| entities are created with the :ref:`Topic QoS <recorder_topic_qos>` of the first Subscriber found on the Topic.
 
-The |ddsrouter| allows filtering DDS :term:`Topics<Topic>` to allow users to configure the DDS :term:`Topics<Topic>` that must be recorded.
+The |ddsrecorder| allows filtering DDS :term:`Topics<Topic>` to allow users to configure the DDS :term:`Topics<Topic>` that must be recorded.
 These data filtering rules can be configured under the ``allowlist`` and ``blocklist`` tags.
 If the ``allowlist`` and ``blocklist`` are not configured, the |ddsrecorder| will recorded the data published on every topic it discovers.
 If both the ``allowlist`` and ``blocklist`` are configured and a topic appears in both of them, the ``blocklist`` has priority and the topic will be blocked.
@@ -186,7 +186,7 @@ Downsampling
 """"""""""""
 
 The ``downsampling`` tag reduces the sampling rate of the received data by only keeping *1* out of every *n* samples received (per topic), where *n* is the value specified under the ``downsampling`` tag.
-When the ``max-rx-rate`` tag is also set, down-sampling only applies to messages that have passed the ``max-rx-rate`` filter.
+When the ``max-rx-rate`` tag is also set, downsampling only applies to messages that have passed the ``max-rx-rate`` filter.
 It only accepts positive integers.
 By default it is set to ``1``; it accepts every message.
 

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -607,13 +607,6 @@ A complete example of all the configurations described on this page can be found
         - name: "topic_name"
           type: "topic_type"
 
-      topics:
-        - name: temperature/*
-          type: temperature/types/*
-          qos:
-            max-rx-rate: 15
-            downsampling: 2
-
       builtin-topics:
         - name: "HelloWorldTopic"
           type: "HelloWorld"
@@ -625,6 +618,13 @@ A complete example of all the configurations described on this page can be found
             ownership: false
             max-rx-rate: 10
             downsampling: 4
+
+      topics:
+        - name: temperature/*
+          type: temperature/types/*
+          qos:
+            max-rx-rate: 15
+            downsampling: 2
 
       ignore-participant-flags: no_filter
       transport: builtin

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -117,19 +117,9 @@ If a topic matches an expression both in the ``allowlist`` and in the ``blocklis
           - name: "*"
             type: HelloWorld
 
-Built-in Topics
-^^^^^^^^^^^^^^^
-
-As seen in :ref:`recorder_topic_filtering`, a |ddsrecorder| uses the QoS of the first Publisher/Subscriber found in every recorded topic, unless manually defined in the :ref:`built-in topics <recorder_builtin_topics>` list.
-This QoS information is stored in the MCAP file along with the user data, and thus a |ddsreplayer| instance is able to publish recorded data preserving the original QoS.
-
-However, the user has the option to manually set the QoS of any topic to be played back through the replayer's builtin-topics list.
-The builtin-topics list is defined in the same form as the ``allowlist`` and ``blocklist``.
-
-This feature also allows to manually force the QoS of a specific topic, so the entities created in such topic follows the specified QoS and not the one first discovered.
 
 Topic Quality of Service
-""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 For every topic contained in this list, both ``name`` and ``type`` must be specified and contain no wildcard characters.
 Apart from these values, the tag ``qos`` under each topic allows to configure the following values:
@@ -194,6 +184,36 @@ Apart from these values, the tag ``qos`` under each topic allows to configure th
               keyed: true             # Topic with key
               max-tx-rate: 25         # Discard messages if less than 100ms elapsed since the last sample was transmitted
 
+.. _replayer_manual_topics:
+
+Topics
+^^^^^^
+
+A subset of QoSs can be manually configured for a specific topic under the tag ``topics``.
+The tag ``topics`` has a required ``name`` tag that accepts wildcard characters.
+It also has two optional tags: a ``type`` tag that accepts wildcard characters, and a ``qos`` tag with the QoSs that the user wants to manually configure.
+If a ``qos`` is not manually configured, it will get its value by discovery.
+
+**Example of usage**
+
+.. code-block:: yaml
+
+    topics:
+      - name: temperature/*
+        type: temperature/types/*
+        qos:
+            max-tx-rate: 15
+
+Built-in Topics
+^^^^^^^^^^^^^^^
+
+As seen in :ref:`recorder_topic_filtering`, a |ddsrecorder| uses the QoS of the first Publisher/Subscriber found in every recorded topic, unless manually defined in the :ref:`built-in topics <recorder_builtin_topics>` list.
+This QoS information is stored in the MCAP file along with the user data, and thus a |ddsreplayer| instance is able to publish recorded data preserving the original QoS.
+
+However, the user has the option to manually set the QoS of any topic to be played back through the replayer's builtin-topics list.
+The builtin-topics list is defined in the same form as the ``allowlist`` and ``blocklist``.
+
+This feature also allows to manually force the QoS of a specific topic, so the entities created in such topic follows the specified QoS and not the one first discovered.
 
 .. _replayer_usage_configuration_domain_id:
 
@@ -437,6 +457,12 @@ A complete example of all the configurations described on this page can be found
       blocklist:
         - name: "topic_name"
           type: "topic_type"
+
+      topics:
+        - name: temperature/*
+          type: temperature/types/*
+          qos:
+            max-tx-rate: 15
 
       builtin-topics:
         - name: "HelloWorldTopic"

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -173,6 +173,12 @@ Apart from these values, the tag ``qos`` under each topic allows to configure th
         - ``false``
         - Topic with / without key
 
+    *   - Max Transmission Rate
+        - ``max-tx-rate``
+        - *float*
+        - *default value*
+        - Maximum sample transmission rate [Hz]
+
 **Example of usage:**
 
     .. code-block:: yaml
@@ -186,6 +192,7 @@ Apart from these values, the tag ``qos`` under each topic allows to configure th
               partitions: true        # Topic with partitions
               ownership: false        # Use QoS SHARED_OWNERSHIP_QOS
               keyed: true             # Topic with key
+              max-tx-rate: 25         # Discard messages if less than 100ms elapsed since the last sample was transmitted
 
 
 .. _replayer_usage_configuration_domain_id:
@@ -361,6 +368,20 @@ By default, data is replayed at the same rate it was published/received.
 However, a user might be interested in playing messages back at a rate different than the original one.
 This can be accomplished through the playback ``rate`` tag, which accepts positive float values (e.g. 0.5 <--> half speed || 2 <--> double speed).
 
+.. _replayer_usage_configuration_max_tx_rate:
+
+Max Transmission Rate
+---------------------
+
+The ``max-tx-rate`` tag limits the frequency [Hz] at which samples are sent by discarding messages transmitted before :code:`1/max-tx-rate` seconds have passed since the last sent message.
+It only accepts non-negative numbers.
+By default it is set to ``0``; it sends samples at an unlimited transmission rate.
+
+.. note::
+
+    The ``max-tx-rate`` tag can be set for topics and globally under the ``replayer`` tag.
+    If both are set, the configuration under topics prevails.
+
 .. _replayer_replay_configuration_replaytypes:
 
 Replay Types
@@ -426,6 +447,7 @@ A complete example of all the configurations described on this page can be found
             keyed: false
             partitions: true
             ownership: false
+            max-tx-rate: 25
 
       ignore-participant-flags: no_filter
       transport: builtin
@@ -453,6 +475,7 @@ A complete example of all the configurations described on this page can be found
         milliseconds: 500
 
       rate: 1.4
+      max-tx-rate: 50
       replay-types: true
 
     specs:

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -231,8 +231,8 @@ If a ``qos`` is not manually configured, it will get its value by discovery.
 .. code-block:: yaml
 
     topics:
-      - name: temperature/*
-        type: temperature/types/*
+      - name: "temperature/*"
+        type: "temperature/types/*"
         qos:
           max-tx-rate: 15
 
@@ -489,8 +489,8 @@ A complete example of all the configurations described on this page can be found
           type: "HelloWorld"
 
       topics:
-        - name: temperature/*
-          type: temperature/types/*
+        - name: "temperature/*"
+          type: "temperature/types/*"
           qos:
             max-tx-rate: 15
 

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -57,7 +57,7 @@ Topic Filtering
 The |ddsreplayer| automatically detects the topics that are being used in a DDS Network.
 The |ddsreplayer| then creates internal DDS :term:`Writers<DataWriter>` to replay the data published on each topic.
 
-The |ddsrouter| allows filtering DDS :term:`Topics<Topic>` to allow users to configure the DDS :term:`Topics<Topic>` that must be replayed.
+The |ddsreplayer| allows filtering DDS :term:`Topics<Topic>` to allow users to configure the DDS :term:`Topics<Topic>` that must be replayed.
 These data filtering rules can be configured under the ``allowlist`` and ``blocklist`` tags.
 If the ``allowlist`` and ``blocklist`` are not configured, the |ddsreplayer| will replayed the data published on every topic it discovers.
 If both the ``allowlist`` and ``blocklist`` are configured and a topic appears in both of them, the ``blocklist`` has priority and the topic will be blocked.

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -176,9 +176,9 @@ By default it is set to ``0``; it sends samples at an unlimited transmission rat
 Manual Topics
 ^^^^^^^^^^^^^
 
-A subset of QoSs can be manually configured for a specific topic under the tag ``topics``.
+A subset of QoS can be manually configured for a specific topic under the tag ``topics``.
 The tag ``topics`` has a required ``name`` tag that accepts wildcard characters.
-It also has two optional tags: a ``type`` tag that accepts wildcard characters, and a ``qos`` tag with the QoSs that the user wants to manually configure.
+It also has two optional tags: a ``type`` tag that accepts wildcard characters, and a ``qos`` tag with the QoS that the user wants to manually configure.
 If a ``qos`` is not manually configured, it will get its value by discovery.
 
 **Example of usage**

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -179,7 +179,13 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
         - ``keyed``
         - *bool*
         - ``false``
-        - Topic with / without key
+        - Topic with / without `key <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/topic/typeSupport/typeSupport.html#data-types-with-a-key>`_
+
+    *   - History Depth
+        - ``history-depth``
+        - *integer*
+        - ``5000``
+        - :ref:`replayer_history_depth`
 
     *   - Max Transmission Rate
         - ``max-tx-rate``
@@ -190,11 +196,11 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
 .. _replayer_history_depth:
 
 History Depth
-^^^^^^^^^^^^^
+"""""""""""""
 
 The ``history-depth`` tag configures the history depth of the Fast DDS internal entities.
 By default, the depth of every RTPS History instance is :code:`5000`, which sets a constraint on the maximum number of samples a |ddsreplayer| instance can deliver to late joiner Readers configured with ``TRANSIENT_LOCAL`` `DurabilityQosPolicyKind <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/standardQosPolicies.html#durabilityqospolicykind>`_.
-Its value should be decreased when the sample size and/or number of created endpoints (increasing with the number of topics and |ddsreplayer| participants) are big enough to cause memory exhaustion issues.
+Its value should be decreased when the sample size and/or number of created endpoints (increasing with the number of topics) are big enough to cause memory exhaustion issues.
 If enough memory is available, however, the ``history-depth`` could be increased to deliver a greater number of samples to late joiners.
 
 .. _replayer_max_tx_rate:
@@ -448,6 +454,11 @@ The execution of a |ddsreplayer| instance ends when the last message contained i
 Note that this last message might be lost after publication, and if reliable `Reliability QoS <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/standardQosPolicies.html#reliabilityqospolicy>`__ is being used, a mechanism should be established to avoid this problematic situation.
 For this purpose, the user can specify the maximum amount of milliseconds (``wait-all-acked-timeout``) to wait on closure until published messages are acknowledged by matched readers.
 Its value is set to ``0`` by default (no wait).
+
+QoS
+^^^
+
+``specs`` supports a ``qos`` **optional** tag to configure the default values of the :ref:`Topic QoS <replayer_topic_qos>`.
 
 .. _replayer_usage_configuration_general_example:
 

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -39,7 +39,6 @@ Topic Filtering
 
 The |ddsreplayer| automatically detects the topics that are being used in a DDS Network.
 The |ddsreplayer| then creates internal DDS :term:`Writers<DataWriter>` to replay the data published on each topic.
-
 The |ddsreplayer| allows filtering DDS :term:`Topics<Topic>` to allow users to configure the DDS :term:`Topics<Topic>` that must be replayed.
 These data filtering rules can be configured under the ``allowlist`` and ``blocklist`` tags.
 If the ``allowlist`` and ``blocklist`` are not configured, the |ddsreplayer| will replayed the data published on every topic it discovers.

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -32,23 +32,6 @@ DDS Configuration
 
 Configuration related to DDS communication.
 
-.. _replayer_builtin_topics:
-
-Built-in Topics
-^^^^^^^^^^^^^^^
-
-The discovery phase can be accelerated by listing topics under the ``builtin-topics`` tag.
-The |ddsreplayer| will create the DataWriters and DataReaders for these topics in the |ddsreplayer| initialization.
-The :ref:`Topic QoS <replayer_topic_qos>` for these topics can be manually configured with a :ref:`Manual Topic <replayer_manual_topics>` and with the :ref:`Specs Topic QoS <replayer_specs_topic_qos>`; if a :ref:`Topic QoS <replayer_topic_qos>` is not configured, it will take its default value.
-
-The ``builtin-topics`` must specify a ``name`` and ``type`` without wildcard characters.
-
-.. code-block:: yaml
-
-    builtin-topics:
-      - name: HelloWorldTopic
-        type: HelloWorld
-
 .. _replayer_topic_filtering:
 
 Topic Filtering
@@ -448,10 +431,6 @@ A complete example of all the configurations described on this page can be found
       blocklist:
         - name: "topic_name"
           type: "topic_type"
-
-      builtin-topics:
-        - name: "HelloWorldTopic"
-          type: "HelloWorld"
 
       topics:
         - name: "temperature/*"

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -133,7 +133,8 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
 
 .. warning::
 
-    The ``TRANSIENT_LOCAL`` durability is not compatible with the ``BEST_EFFORT`` reliability.
+    Manually configuring ``TRANSIENT_LOCAL`` durability may lead to incompatibility issues when the discovered reliability is ``BEST_EFFORT``.
+    Please ensure to always configure the ``reliability`` when configuring the ``durability`` to avoid the issue.
 
 .. _replayer_history_depth:
 

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -131,6 +131,10 @@ For more information on topics, please read the `Fast DDS Topic <https://fast-dd
         - ``0`` (unlimited)
         - :ref:`replayer_max_tx_rate`
 
+.. warning::
+
+    The ``TRANSIENT_LOCAL`` durability is not compatible with the ``BEST_EFFORT`` reliability.
+
 .. _replayer_history_depth:
 
 History Depth

--- a/resources/configurations/recorder/complete_config.yaml
+++ b/resources/configurations/recorder/complete_config.yaml
@@ -13,14 +13,6 @@ dds:
   builtin-topics:
     - name: "HelloWorldTopic"
       type: "HelloWorld"
-      qos:
-        reliability: true
-        durability: true
-        keyed: false
-        partitions: true
-        ownership: false
-        max-rx-rate: 10
-        downsampling: 4
 
   topics:
     - name: temperature/*
@@ -44,8 +36,6 @@ recorder:
   buffer-size: 50
   event-window: 60
   log-publish-time: false
-  max-rx-rate: 20
-  downsampling: 3
   only-with-type: false
   compression:
     algorithm: lz4
@@ -64,3 +54,7 @@ specs:
   threads: 8
   max-pending-samples: 10
   cleanup-period: 90
+
+  qos:
+    max-rx-rate: 20
+    downsampling: 3

--- a/resources/configurations/recorder/complete_config.yaml
+++ b/resources/configurations/recorder/complete_config.yaml
@@ -15,8 +15,8 @@ dds:
       type: "HelloWorld"
 
   topics:
-    - name: temperature/*
-      type: temperature/types/*
+    - name: "temperature/*"
+      type: "temperature/types/*"
       qos:
         max-rx-rate: 15
         downsampling: 2

--- a/resources/configurations/recorder/complete_config.yaml
+++ b/resources/configurations/recorder/complete_config.yaml
@@ -22,6 +22,13 @@ dds:
         max-rx-rate: 10
         downsampling: 4
 
+  topics:
+    - name: temperature/*
+      type: temperature/types/*
+      qos:
+        max-rx-rate: 15
+        downsampling: 2
+
   ignore-participant-flags: filter_same_process
   transport: shm
   whitelist-interfaces:

--- a/resources/configurations/recorder/complete_config.yaml
+++ b/resources/configurations/recorder/complete_config.yaml
@@ -19,8 +19,8 @@ dds:
         keyed: false
         partitions: true
         ownership: false
+        max-rx-rate: 10
         downsampling: 4
-        max-reception-rate: 10
 
   ignore-participant-flags: filter_same_process
   transport: shm
@@ -37,8 +37,8 @@ recorder:
   buffer-size: 50
   event-window: 60
   log-publish-time: false
+  max-rx-rate: 20
   downsampling: 3
-  max-reception-rate: 20
   only-with-type: false
   compression:
     algorithm: lz4

--- a/resources/configurations/replayer/complete_config.yaml
+++ b/resources/configurations/replayer/complete_config.yaml
@@ -10,10 +10,6 @@ dds:
     - name: "topic_to_block"
       type: "type_to_block"
 
-  builtin-topics:
-    - name: "HelloWorldTopic"
-      type: "HelloWorld"
-
   topics:
     - name: "temperature/*"
       type: "temperature/types/*"

--- a/resources/configurations/replayer/complete_config.yaml
+++ b/resources/configurations/replayer/complete_config.yaml
@@ -19,6 +19,7 @@ dds:
         keyed: false
         partitions: true
         ownership: false
+        max-tx-rate: 25
 
   ignore-participant-flags: filter_same_process
   transport: shm
@@ -46,6 +47,7 @@ replayer:
     milliseconds: 500
 
   rate: 1.4
+  max-tx-rate: 50
   replay-types: true
 
 specs:

--- a/resources/configurations/replayer/complete_config.yaml
+++ b/resources/configurations/replayer/complete_config.yaml
@@ -13,13 +13,6 @@ dds:
   builtin-topics:
     - name: "HelloWorldTopic"
       type: "HelloWorld"
-      qos:
-        reliability: true
-        durability: true
-        keyed: false
-        partitions: true
-        ownership: false
-        max-tx-rate: 25
 
   topics:
     - name: temperature/*
@@ -53,9 +46,11 @@ replayer:
     milliseconds: 500
 
   rate: 1.4
-  max-tx-rate: 50
   replay-types: true
 
 specs:
   threads: 12
   wait-all-acked-timeout: 10
+
+  qos:
+    max-tx-rate: 20

--- a/resources/configurations/replayer/complete_config.yaml
+++ b/resources/configurations/replayer/complete_config.yaml
@@ -15,8 +15,8 @@ dds:
       type: "HelloWorld"
 
   topics:
-    - name: temperature/*
-      type: temperature/types/*
+    - name: "temperature/*"
+      type: "temperature/types/*"
       qos:
         max-tx-rate: 15
 

--- a/resources/configurations/replayer/complete_config.yaml
+++ b/resources/configurations/replayer/complete_config.yaml
@@ -21,6 +21,12 @@ dds:
         ownership: false
         max-tx-rate: 25
 
+  topics:
+    - name: temperature/*
+      type: temperature/types/*
+      qos:
+        max-tx-rate: 15
+
   ignore-participant-flags: filter_same_process
   transport: shm
   whitelist-interfaces:


### PR DESCRIPTION
In this version, topics' QoS are configurable. The set of predefined topics' QoS takes precedence over the discovered topics' QoS.

The transmission frequency for sent samples is now also configurable (max-tx-rate). It can be configured generically, per participant, and per topic.

Merge after:
- https://github.com/eProsima/DDS-Router/pull/391
- https://github.com/eProsima/DDS-Pipe/pull/64