### PR TITLE
Make the trigger of the DDS Pipe callbacks configurable

### DIFF
--- a/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
@@ -95,7 +95,6 @@ DdsRecorder::DdsRecorder(
 
     // Create the internal communication (built-in) topics
     const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(type_object_topic());
-
     configuration.ddspipe_configuration.builtin_topics.insert(internal_topic);
 
     // Create Participant Database

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
@@ -94,8 +94,7 @@ DdsRecorder::DdsRecorder(
         mcap_handler_);
 
     // Create the internal communication (built-in) topics
-    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
-            ddspipe::core::types::type_object_topic());
+    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(type_object_topic());
 
     configuration.ddspipe_configuration.builtin_topics.insert(internal_topic);
 

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
@@ -93,9 +93,9 @@ DdsRecorder::DdsRecorder(
         discovery_database_,
         mcap_handler_);
 
-    // Create the internal communication (built-in) topics
-    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(type_object_topic());
-    configuration.ddspipe_configuration.builtin_topics.insert(internal_topic);
+    // Create an internal topic to transmit the dynamic types
+    configuration.ddspipe_configuration.builtin_topics.insert(
+        utils::Heritable<DistributedTopic>::make_heritable(type_object_topic()));
 
     // Create Participant Database
     participants_database_ = std::make_shared<ParticipantsDatabase>();

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
@@ -34,7 +34,7 @@ DdsRecorder::DdsRecorder(
         const yaml::RecorderConfiguration& configuration,
         const DdsRecorderStateCode& init_state,
         const std::string& file_name)
-        : configuration_(configuration)
+    : configuration_(configuration)
 {
     // Create Discovery Database
     discovery_database_ = std::make_shared<DiscoveryDatabase>();

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
@@ -31,9 +31,10 @@ using namespace eprosima::ddsrecorder::participants;
 using namespace eprosima::utils;
 
 DdsRecorder::DdsRecorder(
-        yaml::RecorderConfiguration& configuration,
+        const yaml::RecorderConfiguration& configuration,
         const DdsRecorderStateCode& init_state,
         const std::string& file_name)
+        : configuration_(configuration)
 {
     // Create Discovery Database
     discovery_database_ = std::make_shared<DiscoveryDatabase>();
@@ -42,17 +43,17 @@ DdsRecorder::DdsRecorder(
     payload_pool_ = std::make_shared<FastPayloadPool>();
 
     // Create Thread Pool
-    thread_pool_ = std::make_shared<SlotThreadPool>(configuration.n_threads);
+    thread_pool_ = std::make_shared<SlotThreadPool>(configuration_.n_threads);
 
     // Fill MCAP output file settings
     participants::McapOutputSettings mcap_output_settings;
     if (file_name == "")
     {
-        mcap_output_settings.output_filename = configuration.output_filename;
-        mcap_output_settings.output_filepath = configuration.output_filepath;
+        mcap_output_settings.output_filename = configuration_.output_filename;
+        mcap_output_settings.output_filepath = configuration_.output_filepath;
         mcap_output_settings.prepend_timestamp = true;
-        mcap_output_settings.output_timestamp_format = configuration.output_timestamp_format;
-        mcap_output_settings.output_local_timestamp = configuration.output_local_timestamp;
+        mcap_output_settings.output_timestamp_format = configuration_.output_timestamp_format;
+        mcap_output_settings.output_local_timestamp = configuration_.output_local_timestamp;
     }
     else
     {
@@ -64,14 +65,14 @@ DdsRecorder::DdsRecorder(
     // Create MCAP Handler configuration
     participants::McapHandlerConfiguration handler_config(
         mcap_output_settings,
-        configuration.max_pending_samples,
-        configuration.buffer_size,
-        configuration.event_window,
-        configuration.cleanup_period,
-        configuration.log_publish_time,
-        configuration.only_with_type,
-        configuration.mcap_writer_options,
-        configuration.record_types);
+        configuration_.max_pending_samples,
+        configuration_.buffer_size,
+        configuration_.event_window,
+        configuration_.cleanup_period,
+        configuration_.log_publish_time,
+        configuration_.only_with_type,
+        configuration_.mcap_writer_options,
+        configuration_.record_types);
 
     // Create MCAP Handler
     mcap_handler_ = std::make_shared<participants::McapHandler>(
@@ -81,21 +82,31 @@ DdsRecorder::DdsRecorder(
 
     // Create DynTypes Participant
     dyn_participant_ = std::make_shared<DynTypesParticipant>(
-        configuration.simple_configuration,
+        configuration_.simple_configuration,
         payload_pool_,
         discovery_database_);
     dyn_participant_->init();
 
     // Create Recorder Participant
     recorder_participant_ = std::make_shared<SchemaParticipant>(
-        configuration.recorder_configuration,
+        configuration_.recorder_configuration,
         payload_pool_,
         discovery_database_,
         mcap_handler_);
 
     // Create an internal topic to transmit the dynamic types
-    configuration.ddspipe_configuration.builtin_topics.insert(
+    configuration_.ddspipe_configuration.builtin_topics.insert(
         utils::Heritable<DistributedTopic>::make_heritable(type_object_topic()));
+
+    if (!configuration_.ddspipe_configuration.allowlist.empty())
+    {
+        // The allowlist is not empty. Add the internal topic.
+        WildcardDdsFilterTopic internal_topic;
+        internal_topic.topic_name.set_value(TYPE_OBJECT_TOPIC_NAME);
+
+        configuration_.ddspipe_configuration.allowlist.insert(
+            utils::Heritable<WildcardDdsFilterTopic>::make_heritable(internal_topic));
+    }
 
     // Create Participant Database
     participants_database_ = std::make_shared<ParticipantsDatabase>();
@@ -112,7 +123,7 @@ DdsRecorder::DdsRecorder(
 
     // Create DDS Pipe
     pipe_ = std::make_unique<DdsPipe>(
-        configuration.ddspipe_configuration,
+        configuration_.ddspipe_configuration,
         discovery_database_,
         payload_pool_,
         participants_database_,

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
@@ -65,7 +65,7 @@ public:
      * @param file_name:     Name of the mcap file where data is recorded. If not provided, the one from configuration is used instead.
      */
     DdsRecorder(
-            const yaml::RecorderConfiguration& configuration,
+            yaml::RecorderConfiguration& configuration,
             const DdsRecorderStateCode& init_state,
             const std::string& file_name = "");
 

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
@@ -65,7 +65,7 @@ public:
      * @param file_name:     Name of the mcap file where data is recorded. If not provided, the one from configuration is used instead.
      */
     DdsRecorder(
-            yaml::RecorderConfiguration& configuration,
+            const yaml::RecorderConfiguration& configuration,
             const DdsRecorderStateCode& init_state,
             const std::string& file_name = "");
 
@@ -99,6 +99,9 @@ protected:
 
     static participants::McapHandlerStateCode recorder_to_handler_state_(
             const DdsRecorderStateCode& recorder_state);
+
+    //! Configuration of the DDS Recorder
+    yaml::RecorderConfiguration configuration_;
 
     //! Payload Pool
     std::shared_ptr<ddspipe::core::PayloadPool> payload_pool_;

--- a/ddsrecorder_participants/src/cpp/replayer/ReplayerParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/ReplayerParticipant.cpp
@@ -33,10 +33,6 @@ ReplayerParticipant::ReplayerParticipant(
         payload_pool,
         discovery_database)
 {
-    // Delete endpoint discovery/removal callbacks inserted in DDS-Pipe core.
-    // This is to avoid the creation of useless bridges and tracks created when discovering endpoints in topics other
-    // than the ones present in MCAP.
-    discovery_database_->clear_all_callbacks();
 }
 
 std::shared_ptr<IReader> ReplayerParticipant::create_reader(

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -132,7 +132,7 @@ void RecorderConfiguration::load_ddsrecorder_configuration_(
         ddspipe_configuration.init_enabled = true;
 
         // The recorder's DdsPipe trigger is the discovery of a writer
-        ddspipe_configuration.entity_creation_trigger = EntityCreationTrigger::WRITER;
+        ddspipe_configuration.discovery_trigger = DiscoveryTrigger::WRITER;
 
         // Initialize controller domain with the same as the one being recorded
         // WARNING: dds tag must have been parsed beforehand

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -361,12 +361,6 @@ void RecorderConfiguration::load_dds_configuration_(
     {
         ddspipe_configuration.allowlist = YamlReader::get_set<utils::Heritable<IFilterTopic>>(yml, ALLOWLIST_TAG,
                         version);
-
-        // Add to allowlist always the type object topic
-        WildcardDdsFilterTopic internal_topic;
-        internal_topic.topic_name.set_value(TYPE_OBJECT_TOPIC_NAME);
-        ddspipe_configuration.allowlist.insert(
-            utils::Heritable<WildcardDdsFilterTopic>::make_heritable(internal_topic));
     }
 
     /////

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -129,7 +129,7 @@ void RecorderConfiguration::load_ddsrecorder_configuration_(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
 
         // The DDS Pipe should be enabled on start up.
-        ddspipe_configuration.init_enabled = false;
+        ddspipe_configuration.init_enabled = true;
 
         // The recorder's DdsPipe trigger is the discovery of a writer
         ddspipe_configuration.entity_creation_trigger = EntityCreationTrigger::WRITER;
@@ -394,12 +394,6 @@ void RecorderConfiguration::load_dds_configuration_(
         ddspipe_configuration.builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
                         version);
     }
-
-    // Create the internal communication (built-in) topics
-    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
-            ddspipe::core::types::type_object_topic());
-            
-    ddspipe_configuration.builtin_topics.insert(internal_topic);
 }
 
 void RecorderConfiguration::load_ddsrecorder_configuration_from_file_(

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -129,7 +129,10 @@ void RecorderConfiguration::load_ddsrecorder_configuration_(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
 
         // The DDS Pipe should be enabled on start up.
-        ddspipe_configuration.init_enabled = true;
+        ddspipe_configuration.init_enabled = false;
+
+        // The recorder's DdsPipe trigger is the discovery of a writer
+        ddspipe_configuration.entity_creation_trigger = EntityCreationTrigger::WRITER;
 
         // Initialize controller domain with the same as the one being recorded
         // WARNING: dds tag must have been parsed beforehand
@@ -391,6 +394,12 @@ void RecorderConfiguration::load_dds_configuration_(
         ddspipe_configuration.builtin_topics = YamlReader::get_set<utils::Heritable<DistributedTopic>>(yml, BUILTIN_TAG,
                         version);
     }
+
+    // Create the internal communication (built-in) topics
+    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
+            ddspipe::core::types::type_object_topic());
+            
+    ddspipe_configuration.builtin_topics.insert(internal_topic);
 }
 
 void RecorderConfiguration::load_ddsrecorder_configuration_from_file_(

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -292,12 +292,6 @@ void ReplayerConfiguration::load_dds_configuration_(
         ddspipe_configuration.manual_topics =
                 std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
     }
-
-    // Create the internal communication (built-in) topics
-    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
-            ddspipe::core::types::type_object_topic());
-
-    ddspipe_configuration.builtin_topics.insert(internal_topic);
 }
 
 void ReplayerConfiguration::load_ddsreplayer_configuration_from_file_(

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -136,7 +136,7 @@ void ReplayerConfiguration::load_ddsreplayer_configuration_(
         ddspipe_configuration.init_enabled = true;
 
         // The replayer's DdsPipe doesn't get triggered by the discovery of entities
-        ddspipe_configuration.entity_creation_trigger = EntityCreationTrigger::NONE;
+        ddspipe_configuration.discovery_trigger = DiscoveryTrigger::NONE;
     }
     catch (const std::exception& e)
     {

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -134,6 +134,9 @@ void ReplayerConfiguration::load_ddsreplayer_configuration_(
 
         // The DDS Pipe should be enabled on start up.
         ddspipe_configuration.init_enabled = true;
+
+        // The replayer's DdsPipe doesn't get triggered by the discovery of entities
+        ddspipe_configuration.entity_creation_trigger = EntityCreationTrigger::NONE;
     }
     catch (const std::exception& e)
     {
@@ -289,6 +292,12 @@ void ReplayerConfiguration::load_dds_configuration_(
         ddspipe_configuration.manual_topics =
                 std::vector<ManualTopic>(manual_topics.begin(), manual_topics.end());
     }
+
+    // Create the internal communication (built-in) topics
+    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
+            ddspipe::core::types::type_object_topic());
+
+    ddspipe_configuration.builtin_topics.insert(internal_topic);
 }
 
 void ReplayerConfiguration::load_ddsreplayer_configuration_from_file_(

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -59,16 +59,13 @@ DdsReplayer::DdsReplayer(
     , dyn_publisher_(nullptr)
 {
     // Create Discovery Database
-    discovery_database_ =
-            std::make_shared<DiscoveryDatabase>();
+    discovery_database_ = std::make_shared<DiscoveryDatabase>();
 
     // Create Payload Pool
-    payload_pool_ =
-            std::make_shared<FastPayloadPool>();
+    payload_pool_ = std::make_shared<FastPayloadPool>();
 
     // Create Thread Pool
-    thread_pool_ =
-            std::make_shared<SlotThreadPool>(configuration.n_threads);
+    thread_pool_ = std::make_shared<SlotThreadPool>(configuration.n_threads);
 
     // Create MCAP Reader Participant
     mcap_reader_participant_ = std::make_shared<McapReaderParticipant>(
@@ -137,12 +134,12 @@ DdsReplayer::DdsReplayer(
         }
     }
 
-    // Create the internal communication (built-in) topics
-    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(type_object_topic());
-    configuration.ddspipe_configuration.builtin_topics.insert(internal_topic);
-
-    // Generate builtin-topics list by combining information from YAML and MCAP files
+    // Generate builtin-topics from the topics in the MCAP file
     configuration.ddspipe_configuration.builtin_topics = generate_builtin_topics_(configuration, input_file);
+
+    // Create an internal topic to transmit the dynamic types
+    configuration.ddspipe_configuration.builtin_topics.insert(
+        utils::Heritable<DistributedTopic>::make_heritable(type_object_topic()));
 
     // Create DDS Pipe
     pipe_ = std::make_unique<DdsPipe>(

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -33,6 +33,8 @@
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastrtps/attributes/ParticipantAttributes.h>
 
+#include <ddspipe_core/types/dynamic_types/types.hpp>
+
 #include <ddsrecorder_participants/common/types/DynamicTypesCollection.hpp>
 #include <ddsrecorder_participants/common/types/DynamicTypesCollectionPubSubTypes.hpp>
 #include <ddsrecorder_participants/constants.hpp>
@@ -136,9 +138,7 @@ DdsReplayer::DdsReplayer(
     }
 
     // Create the internal communication (built-in) topics
-    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
-            ddspipe::core::types::type_object_topic());
-
+    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(type_object_topic());
     configuration.ddspipe_configuration.builtin_topics.insert(internal_topic);
 
     // Generate builtin-topics list by combining information from YAML and MCAP files

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -135,6 +135,12 @@ DdsReplayer::DdsReplayer(
         }
     }
 
+    // Create the internal communication (built-in) topics
+    const auto& internal_topic = utils::Heritable<DistributedTopic>::make_heritable(
+            ddspipe::core::types::type_object_topic());
+
+    configuration.ddspipe_configuration.builtin_topics.insert(internal_topic);
+
     // Generate builtin-topics list by combining information from YAML and MCAP files
     configuration.ddspipe_configuration.builtin_topics = generate_builtin_topics_(configuration, input_file);
 

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -137,10 +137,6 @@ DdsReplayer::DdsReplayer(
     // Generate builtin-topics from the topics in the MCAP file
     configuration.ddspipe_configuration.builtin_topics = generate_builtin_topics_(configuration, input_file);
 
-    // Create an internal topic to transmit the dynamic types
-    configuration.ddspipe_configuration.builtin_topics.insert(
-        utils::Heritable<DistributedTopic>::make_heritable(type_object_topic()));
-
     // Create DDS Pipe
     pipe_ = std::make_unique<DdsPipe>(
         configuration.ddspipe_configuration,

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -32,5 +32,5 @@ Next release will include the following **DDS Recorder tool configuration featur
 Next release will include the following **DDS Replayer tool configuration features**:
 
 * New configuration option (``topics``) to configure the :ref:`Manual Topics <replayer_manual_topics>`.
-* New configuration option (``max-tx-rate``) to configure the :ref:`Max transmission rate <replayer_usage_configuration_max_tx_rate>`.
+* New configuration option (``max-tx-rate``) to configure the :ref:`Max transmission rate <replayer_max_tx_rate>`.
 * Remove the support for `Built-in Topics <https://dds-recorder.readthedocs.io/en/v0.2.0/rst/replaying/usage/configuration.html#built-in-topics>`_.

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -33,6 +33,17 @@ DDS Configuration
 
 Configuration related to DDS communication.
 
+.. _recorder_usage_configuration_domain_id:
+
+DDS Domain
+^^^^^^^^^^
+
+Tag ``domain`` configures the :term:`Domain Id`.
+
+.. code-block:: yaml
+
+    domain: 101
+
 .. _recorder_builtin_topics:
 
 Built-in Topics
@@ -55,7 +66,7 @@ The ``builtin-topics`` must specify a ``name`` and ``type`` without wildcard cha
 .. _recorder_topic_filtering:
 
 Topic Filtering
----------------
+^^^^^^^^^^^^^^^
 
 The |ddsrecorder| automatically detects the topics that are being used in a DDS Network.
 The |ddsrecorder| then creates internal DDS :term:`Readers<DataReader>` to record the data published on each topic.
@@ -212,18 +223,6 @@ If a ``qos`` is not manually configured, it will get its value by discovery.
 .. note::
 
     The :ref:`Topic QoS <recorder_topic_qos>` configured in the Manual Topics take precedence over the :ref:`Specs Topic QoS <recorder_specs_topic_qos>`.
-
-.. _recorder_usage_configuration_domain_id:
-
-DDS Domain
-^^^^^^^^^^
-
-Tag ``domain`` configures the :term:`Domain Id`.
-
-.. code-block:: yaml
-
-    domain: 101
-
 
 .. _recorder_ignore_participant_flags:
 

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -285,11 +285,6 @@ Example:
 
 See `Interface Whitelist <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/whitelist.html>`_ for more information.
 
-.. warning::
-
-    When providing an interface whitelist, external participants with which communication is desired must also be configured with interface whitelisting.
-
-
 Recorder Configuration
 ----------------------
 

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -255,11 +255,6 @@ Example:
 
 See `Interface Whitelist <https://fast-dds.docs.eprosima.com/en/latest/fastdds/transport/whitelist.html>`_ for more information.
 
-.. warning::
-
-    When providing an interface whitelist, external participants with which communication is desired must also be configured with interface whitelisting.
-
-
 Replay Configuration
 --------------------
 

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -165,10 +165,6 @@ The ``max-tx-rate`` tag limits the frequency [Hz] at which samples are sent by d
 It only accepts non-negative numbers.
 By default it is set to ``0``; it sends samples at an unlimited transmission rate.
 
-.. note::
-
-    The ``max-tx-rate`` tag can be set (in order of precedence) for topics and globally in specs.
-
 .. _replayer_manual_topics:
 
 Manual Topics

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -32,10 +32,21 @@ DDS Configuration
 
 Configuration related to DDS communication.
 
+.. _replayer_usage_configuration_domain_id:
+
+DDS Domain
+^^^^^^^^^^
+
+Tag ``domain`` configures the :term:`Domain Id`.
+
+.. code-block:: yaml
+
+    domain: 101
+
 .. _replayer_topic_filtering:
 
 Topic Filtering
----------------
+^^^^^^^^^^^^^^^
 
 The |ddsreplayer| automatically detects the topics that are being used in a DDS Network.
 The |ddsreplayer| then creates internal DDS :term:`Writers<DataWriter>` to replay the data published on each topic.
@@ -156,7 +167,7 @@ By default it is set to ``0``; it sends samples at an unlimited transmission rat
 
 .. note::
 
-    The ``max-tx-rate`` tag can be set (in order of precedence) for topics, for participants, and globally in specs.
+    The ``max-tx-rate`` tag can be set (in order of precedence) for topics and globally in specs.
 
 .. _replayer_manual_topics:
 
@@ -181,17 +192,6 @@ If a ``qos`` is not manually configured, it will get its value by discovery.
 .. note::
 
     The :ref:`Topic QoS <replayer_topic_qos>` configured in the Manual Topics take precedence over the :ref:`Specs Topic QoS <replayer_specs_topic_qos>`.
-
-.. _replayer_usage_configuration_domain_id:
-
-DDS Domain
-^^^^^^^^^^
-
-Tag ``domain`` configures the :term:`Domain Id`.
-
-.. code-block:: yaml
-
-    domain: 101
 
 
 .. _replayer_ignore_participant_flags:

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -165,6 +165,11 @@ The ``max-tx-rate`` tag limits the frequency [Hz] at which samples are sent by d
 It only accepts non-negative numbers.
 By default it is set to ``0``; it sends samples at an unlimited transmission rate.
 
+.. note::
+
+    The ``max-tx-rate`` tag can be set for topics and globally under the ``replayer`` tag.
+    If both are set, the configuration under topics prevails.
+
 .. _replayer_manual_topics:
 
 Manual Topics
@@ -345,20 +350,6 @@ Playback Rate
 By default, data is replayed at the same rate it was published/received.
 However, a user might be interested in playing messages back at a rate different than the original one.
 This can be accomplished through the playback ``rate`` tag, which accepts positive float values (e.g. 0.5 <--> half speed || 2 <--> double speed).
-
-.. _replayer_usage_configuration_max_tx_rate:
-
-Max Transmission Rate
----------------------
-
-The ``max-tx-rate`` tag limits the frequency [Hz] at which samples are sent by discarding messages transmitted before :code:`1/max-tx-rate` seconds have passed since the last sent message.
-It only accepts non-negative numbers.
-By default it is set to ``0``; it sends samples at an unlimited transmission rate.
-
-.. note::
-
-    The ``max-tx-rate`` tag can be set for topics and globally under the ``replayer`` tag.
-    If both are set, the configuration under topics prevails.
 
 .. _replayer_replay_configuration_replaytypes:
 

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -165,11 +165,6 @@ The ``max-tx-rate`` tag limits the frequency [Hz] at which samples are sent by d
 It only accepts non-negative numbers.
 By default it is set to ``0``; it sends samples at an unlimited transmission rate.
 
-.. note::
-
-    The ``max-tx-rate`` tag can be set for topics and globally under the ``replayer`` tag.
-    If both are set, the configuration under topics prevails.
-
 .. _replayer_manual_topics:
 
 Manual Topics


### PR DESCRIPTION
In the previous version, the DDS Pipe's callbacks were only triggered by the discovery of readers, so the DDS-Record-Replay had to simulate the creation of a reader to trigger the creation of the Bridge. In this version, the entity type that triggers the callbacks is configurable. The DDS Recorder triggers them with the discovery of writers, and the DDS Replayer doesn't trigger them by discovery, and just starts replaying the data as soon as the program is launched. 

Merge after:
- https://github.com/eProsima/DDS-Record-Replay/pull/86
- https://github.com/eProsima/DDS-Pipe/pull/67