### PR TITLE
Add internal builtin topics as DdsTopic(s)

### DIFF
--- a/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.cpp
@@ -96,7 +96,7 @@ DdsRecorder::DdsRecorder(
 
     // Create an internal topic to transmit the dynamic types
     configuration_.ddspipe_configuration.builtin_topics.insert(
-        utils::Heritable<DistributedTopic>::make_heritable(type_object_topic()));
+        utils::Heritable<DdsTopic>::make_heritable(type_object_topic()));
 
     if (!configuration_.ddspipe_configuration.allowlist.empty())
     {


### PR DESCRIPTION
PR https://github.com/eProsima/DDS-Record-Replay/pull/87 introduced a regression in which internal builtin topics were added as `DistributedTopic` instead of `DdsTopic`. As a consequence, these were not well processed when an allowlist was being provided (casting to `DdsTopic` failed).