### PR TITLE
Controller tool: recorder found on status reader matched

### DIFF
--- a/controller/controller_tool/tool/src/py/Controller.py
+++ b/controller/controller_tool/tool/src/py/Controller.py
@@ -169,7 +169,7 @@ class Controller(QObject):
         writer_qos.reliability().kind = fastdds.RELIABLE_RELIABILITY_QOS
         writer_qos.durability().kind = fastdds.VOLATILE_DURABILITY_QOS
         writer_qos.history().kind = fastdds.KEEP_LAST_HISTORY_QOS
-        writer_qos.history().size = 10
+        writer_qos.history().depth = 10
         self.command_writer = self.publisher.create_datawriter(
             self.command_topic, writer_qos)
 
@@ -184,7 +184,7 @@ class Controller(QObject):
         reader_qos.reliability().kind = fastdds.RELIABLE_RELIABILITY_QOS
         reader_qos.durability().kind = fastdds.TRANSIENT_LOCAL_DURABILITY_QOS
         reader_qos.history().kind = fastdds.KEEP_LAST_HISTORY_QOS
-        reader_qos.history().size = 10
+        reader_qos.history().depth = 10
         self.status_reader = self.subscriber.create_datareader(
             self.status_topic, reader_qos, self.status_reader_listener)
 


### PR DESCRIPTION
This PR is a slight improvement of the controller tool demonstrator, by using the trigger of its status reader matched callback as signal for a recorder instance discovery (instead of the command writer matched callback). This way, when spying (with Fast-DDS-spy) or recording (with another DDS-Recorder instance), this message would not be falsely displayed.

Note however that this only covers a subset of corner cases, as for example with a DDS-Router forwarding status messages the message would still be falsely displayed in the controller (although perhaps this is the right behaviour, as this would (most likely) mean that there exists a DDS-Recorder at some domain/network bridged by the router instance). A definitive solution could be, for example, adding ad-hoc properties to the CommandReceiver's internal DomainParticipant, but unfortunately these cannot be parsed when using Fast-DDS Python wrapper at the time of this writting.