### PR TITLE
Copy attachments buffer when parsing summary [20078]

### DIFF
--- a/thirdparty/mcap/mcap/reader.hpp
+++ b/thirdparty/mcap/mcap/reader.hpp
@@ -490,6 +490,7 @@ private:
   bool parsedSummary_ = false;
 
   void reset_();
+  void clear_attachments_();
   Status readSummarySection_(IReadable& reader);
   Status readSummaryFromScan_(IReadable& reader);
 };

--- a/thirdparty/mcap/mcap/reader.inl
+++ b/thirdparty/mcap/mcap/reader.inl
@@ -515,7 +515,7 @@ Status McapReader::readSummaryFromScan_(IReadable& reader) {
     Attachment attachment_copy = attachment;
     attachment_copy.data = (std::byte*)std::malloc(attachment.dataSize);
     std::memcpy((void*)attachment_copy.data, attachment.data, attachment.dataSize);
-    attachments_.emplace(attachment_copy.name, attachment_copy);
+    attachments_.emplace(attachment_copy.name, std::move(attachment_copy));
   };
   typedReader.onMetadata = [&](const Metadata& metadata, ByteOffset fileOffset) {
     MetadataIndex metadataIndex{metadata, fileOffset};


### PR DESCRIPTION
MCAP C++ library was previously modified so that attachments (and metadata) are stored in a class attribute, accessible through public methods, while parsing a file. However, attachments were not well stored as their internal buffer was not being copied (only their address), and after parsing this memory could be deallocated or reused in posterior actions.

Related:
 - https://github.com/eProsima/DDS-Record-Replay/pull/82
 - https://github.com/foxglove/mcap/issues/976