### PR TITLE
Allocate enough memory when deserializing types [20095]

### DIFF
--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -482,7 +482,7 @@ fastrtps::types::TypeIdentifier DdsReplayer::deserialize_type_identifier_(
 #endif // if __BIG_ENDIAN__
 
     // Reserve payload and create buffer
-    uint16_t parameter_length = cdr_message->length;
+    const auto parameter_length = cdr_message->length;
     fastrtps::rtps::SerializedPayload_t payload(parameter_length);
     fastcdr::FastBuffer fastbuffer((char*)payload.data, parameter_length);
 
@@ -520,7 +520,7 @@ fastrtps::types::TypeObject DdsReplayer::deserialize_type_object_(
 #endif // if __BIG_ENDIAN__
 
     // Reserve payload and create buffer
-    uint16_t parameter_length = cdr_message->length;
+    const auto parameter_length = cdr_message->length;
     fastrtps::rtps::SerializedPayload_t payload(parameter_length);
     fastcdr::FastBuffer fastbuffer((char*)payload.data, parameter_length);
 


### PR DESCRIPTION
In the previous version, the DDS Replayer was creating a buffer with a uint16_t size to deserialize data in, and, sometimes, it was bumping into NotEnoughMemoryExceptions. In the version, the buffer's size is created with a uint32_t, fixing the exceptions.