### PR TITLE
Reload the internal topics when reloading the configuration file

### DIFF
--- a/ddsrecorder/src/cpp/main.cpp
+++ b/ddsrecorder/src/cpp/main.cpp
@@ -216,7 +216,7 @@ int main(
 
             logUser(
                 DDSRECORDER_EXECUTION,
-                "Not configuration file given, using default file " << file_path << ".");
+                "No configuration file given, using default file " << file_path << ".");
         }
     }
     else

--- a/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
+++ b/ddsrecorder/src/cpp/tool/DdsRecorder.hpp
@@ -70,15 +70,15 @@ public:
             const std::string& file_name = "");
 
     /**
-     * Reload allowed topics list.
+     * Reconfigure the Recorder with the new configuration.
      *
-     * @param allowed_topics: Allowed topics list to be loaded.
+     * @param new_configuration: The configuration to replace the previous configuration with.
      *
      * @return \c RETCODE_OK if allowed topics list has been updated correctly
      * @return \c RETCODE_NO_DATA if new allowed topics list is the same as the previous one
      */
     utils::ReturnCode reload_configuration(
-            const yaml::RecorderConfiguration& new_configuration);
+            yaml::RecorderConfiguration& new_configuration);
 
     //! Start recorder (\c mcap_handler_)
     void start();
@@ -96,6 +96,14 @@ public:
     void trigger_event();
 
 protected:
+
+    /**
+     * Load the Recorder's internal topics into a configuration object.
+     *
+     * @param configuration: The configuration to load the internal topics into.
+     */
+    void load_internal_topics_(
+            yaml::RecorderConfiguration& configuration);
 
     static participants::McapHandlerStateCode recorder_to_handler_state_(
             const DdsRecorderStateCode& recorder_state);

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -128,10 +128,9 @@ void RecorderConfiguration::load_ddsrecorder_configuration_(
         ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
 
-        // The DDS Pipe should be enabled on start up.
         ddspipe_configuration.init_enabled = true;
 
-        // The recorder's DdsPipe trigger is the discovery of a writer
+        // Only trigger the DdsPipe's callbacks when discovering or removing writers
         ddspipe_configuration.discovery_trigger = DiscoveryTrigger::WRITER;
 
         // Initialize controller domain with the same as the one being recorded

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -132,10 +132,9 @@ void ReplayerConfiguration::load_ddsreplayer_configuration_(
         ddspipe_configuration.blocklist.insert(
             utils::Heritable<WildcardDdsFilterTopic>::make_heritable(rpc_response_topic));
 
-        // The DDS Pipe should be enabled on start up.
         ddspipe_configuration.init_enabled = true;
 
-        // The replayer's DdsPipe doesn't get triggered by the discovery of entities
+        // Don't trigger the DdsPipe's callbacks when discovering or removing external entities
         ddspipe_configuration.discovery_trigger = DiscoveryTrigger::NONE;
     }
     catch (const std::exception& e)

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.hpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.hpp
@@ -72,9 +72,9 @@ public:
     ~DdsReplayer();
 
     /**
-     * Reload allowed topics list.
+     * Reconfigure the Replayer with the new configuration.
      *
-     * @param allowed_topics: Allowed topics list to be loaded.
+     * @param new_configuration: The configuration to replace the previous configuration with.
      *
      * @return \c RETCODE_OK if allowed topics list has been updated correctly
      * @return \c RETCODE_NO_DATA if new allowed topics list is the same as the previous one


### PR DESCRIPTION
In the previous version, adding an allowlist while the DdsRecorder was running made the DdsRecorder not save the type information of the allowed topics. Now, the DdsRecorder always saves the type information of allowed topics.