### PR TITLE
[20274] Validate the YAML configuration file on parsing

### DIFF
--- a/ddsrecorder/src/cpp/main.cpp
+++ b/ddsrecorder/src/cpp/main.cpp
@@ -180,6 +180,14 @@ CommandCode state_to_command(
     }
 }
 
+int exit(ProcessReturnCode code)
+{
+    // Delete the consumers before closing
+    eprosima::utils::Log::ClearConsumers();
+
+    return static_cast<int>(code);
+}
+
 int main(
         int argc,
         char** argv)
@@ -193,15 +201,15 @@ int main(
 
     if (arg_parse_result == ProcessReturnCode::help_argument)
     {
-        return static_cast<int>(ProcessReturnCode::success);
+        return exit(ProcessReturnCode::success);
     }
     else if (arg_parse_result == ProcessReturnCode::version_argument)
     {
-        return static_cast<int>(ProcessReturnCode::success);
+        return exit(ProcessReturnCode::success);
     }
     else if (arg_parse_result != ProcessReturnCode::success)
     {
-        return static_cast<int>(arg_parse_result);
+        return exit(arg_parse_result);
     }
 
     // Check file is in args, else get the default file
@@ -225,7 +233,7 @@ int main(
             EPROSIMA_LOG_ERROR(
                 DDSRECORDER_ARGS,
                 "File '" << commandline_args.file_path << "' does not exist or it is not accessible.");
-            return static_cast<int>(ProcessReturnCode::required_argument_failed);
+            return exit(ProcessReturnCode::required_argument_failed);
         }
     }
 
@@ -574,23 +582,17 @@ int main(
                 "Error Loading DDS Recorder Configuration from file " << commandline_args.file_path <<
                 ". Error message:\n " <<
                 e.what());
-        return static_cast<int>(ProcessReturnCode::execution_failed);
+        return exit(ProcessReturnCode::execution_failed);
     }
     catch (const eprosima::utils::InitializationException& e)
     {
         EPROSIMA_LOG_ERROR(DDSRECORDER_ERROR,
                 "Error Initializing DDS Recorder. Error message:\n " <<
                 e.what());
-        return static_cast<int>(ProcessReturnCode::execution_failed);
+        return exit(ProcessReturnCode::execution_failed);
     }
 
     logUser(DDSRECORDER_EXECUTION, "Finishing DDS Recorder execution correctly.");
 
-    // Force print every log before closing
-    eprosima::utils::Log::Flush();
-
-    // Delete the consumers before closing
-    eprosima::utils::Log::ClearConsumers();
-
-    return static_cast<int>(ProcessReturnCode::success);
+    return exit(ProcessReturnCode::success);
 }

--- a/ddsrecorder/src/cpp/main.cpp
+++ b/ddsrecorder/src/cpp/main.cpp
@@ -400,9 +400,12 @@ int main(
                             " command.");
                 }
 
-                // Reload YAML configuration file, in case it changed during STOPPED state
-                // NOTE: Changes to all (but controller specific) recorder configuration options are taken into account
-                configuration = eprosima::ddsrecorder::yaml::RecorderConfiguration(commandline_args.file_path);
+                if (prev_command != CommandCode::close)
+                {
+                    // Reload YAML configuration file, in case it changed during STOPPED state
+                    // NOTE: Changes to all (but controller specific) recorder configuration options are taken into account
+                    configuration = eprosima::ddsrecorder::yaml::RecorderConfiguration(commandline_args.file_path);
+                }
 
                 // Create DDS Recorder
                 auto recorder = std::make_unique<DdsRecorder>(

--- a/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
@@ -250,9 +250,9 @@ ProcessReturnCode parse_arguments(
                     break;
 
                 case optionIndex::ACTIVATE_DEBUG:
-                    commandline_args.log_filter[utils::VerbosityKind::Error].set_value("");
-                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("DDSRECORDER");
-                    commandline_args.log_filter[utils::VerbosityKind::Info].set_value("DDSRECORDER");
+                    commandline_args.log_filter.error.set_value("");
+                    commandline_args.log_filter.warning.set_value("DDSRECORDER");
+                    commandline_args.log_filter.info.set_value("DDSRECORDER");
                     commandline_args.log_verbosity = utils::VerbosityKind::Info;
                     break;
 
@@ -261,9 +261,9 @@ ProcessReturnCode parse_arguments(
                     break;
 
                 case optionIndex::LOG_FILTER:
-                    commandline_args.log_filter[utils::VerbosityKind::Error].set_value(opt.arg);
-                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value(opt.arg);
-                    commandline_args.log_filter[utils::VerbosityKind::Info].set_value(opt.arg);
+                    commandline_args.log_filter.error.set_value(opt.arg);
+                    commandline_args.log_filter.warning.set_value(opt.arg);
+                    commandline_args.log_filter.info.set_value(opt.arg);
                     break;
 
                 case optionIndex::LOG_VERBOSITY:

--- a/ddsrecorder_participants/test/unittest/monitoring/ddsrecorder_status/logging/LogMonitorDdsRecorderStatusTest.cpp
+++ b/ddsrecorder_participants/test/unittest/monitoring/ddsrecorder_status/logging/LogMonitorDdsRecorderStatusTest.cpp
@@ -44,7 +44,7 @@ public:
 
         utils::BaseLogConfiguration log_conf;
         log_conf.verbosity = utils::VerbosityKind::Info;
-        log_conf.filter[utils::VerbosityKind::Info].set_value("MONITOR_DATA");
+        log_conf.filter.info.set_value("MONITOR_DATA");
 
         utils::Log::SetVerbosity(log_conf.verbosity);
 

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
@@ -114,6 +114,10 @@ protected:
             const Yaml& yml,
             const ddspipe::yaml::YamlReaderVersion& version);
 
+    void load_output_configuration_(
+            const Yaml& yml,
+            const ddspipe::yaml::YamlReaderVersion& version);
+
     void load_controller_configuration_(
             const Yaml& yml,
             const ddspipe::yaml::YamlReaderVersion& version);

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp
@@ -25,6 +25,7 @@
 
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/configuration/MonitorConfiguration.hpp>
+#include <ddspipe_core/types/dds/DomainId.hpp>
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>

--- a/ddsrecorder_yaml/src/cpp/recorder/CommandlineArgsRecorder.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/CommandlineArgsRecorder.cpp
@@ -20,10 +20,9 @@ namespace yaml {
 
 CommandlineArgsRecorder::CommandlineArgsRecorder()
 {
-    log_filter[utils::VerbosityKind::Info].set_value("DDSRECORDER", utils::FuzzyLevelValues::fuzzy_level_default);
-    log_filter[utils::VerbosityKind::Warning].set_value("DDSRECORDER",
-            utils::FuzzyLevelValues::fuzzy_level_default);
-    log_filter[utils::VerbosityKind::Error].set_value("", utils::FuzzyLevelValues::fuzzy_level_default);
+    log_filter.info.set_value("DDSRECORDER", utils::FuzzyLevelValues::fuzzy_level_default);
+    log_filter.warning.set_value("DDSRECORDER", utils::FuzzyLevelValues::fuzzy_level_default);
+    log_filter.error.set_value("", utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool CommandlineArgsRecorder::is_valid(

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReader.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReader.cpp
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <set>
+
 #include <mcap/mcap.hpp>
 
 #include <ddspipe_yaml/YamlReader.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
 
 #include <ddsrecorder_yaml/recorder/yaml_configuration_tags.hpp>
 
@@ -30,6 +33,14 @@ YamlReader::get<mcap::McapWriterOptions>(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    static const std::set<TagType> tags{
+        RECORDER_COMPRESSION_SETTINGS_ALGORITHM_TAG,
+        RECORDER_COMPRESSION_SETTINGS_LEVEL_TAG,
+        RECORDER_COMPRESSION_SETTINGS_FORCE_TAG,
+    };
+
+    YamlValidator::validate_tags(yml, tags);
+
     mcap::McapWriterOptions mcap_writer_options{"ros2"};
 
     // Parse optional compression algorithm

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#include <set>
+
 #include <cpp_utils/Log.hpp>
 #include <cpp_utils/utils.hpp>
 
@@ -29,6 +31,7 @@
 #include <ddspipe_yaml/yaml_configuration_tags.hpp>
 #include <ddspipe_yaml/Yaml.hpp>
 #include <ddspipe_yaml/YamlManager.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
 
 #include <ddsrecorder_yaml/recorder/yaml_configuration_tags.hpp>
 #include <ddsrecorder_yaml/recorder/YamlReaderConfiguration.hpp>
@@ -122,6 +125,14 @@ void RecorderConfiguration::load_ddsrecorder_configuration_(
         recorder_configuration->app_metadata = "";
         recorder_configuration->is_repeater = false;
 
+        static const std::set<TagType> tags{
+            RECORDER_RECORDER_TAG,
+            SPECS_TAG,
+            RECORDER_DDS_TAG,
+            RECORDER_REMOTE_CONTROLLER_TAG};
+
+        YamlValidator::validate_tags(yml, tags);
+
         /////
         // Get optional Recorder configuration options
         if (YamlReader::is_tag_present(yml, RECORDER_RECORDER_TAG))
@@ -136,7 +147,6 @@ void RecorderConfiguration::load_ddsrecorder_configuration_(
 
         /////
         // Get optional specs configuration
-        // WARNING: Parse builtin topics (dds tag) AFTER specs, as some topic-specific default values are set there
         if (YamlReader::is_tag_present(yml, SPECS_TAG))
         {
             auto specs_yml = YamlReader::get_value_in_tag(yml, SPECS_TAG);
@@ -210,9 +220,31 @@ void RecorderConfiguration::load_recorder_configuration_(
         const Yaml& yml,
         const YamlReaderVersion& version)
 {
+    static const std::set<TagType> tags{
+        RECORDER_OUTPUT_TAG,
+        RECORDER_BUFFER_SIZE_TAG,
+        RECORDER_EVENT_WINDOW_TAG,
+        RECORDER_LOG_PUBLISH_TIME_TAG,
+        RECORDER_ONLY_WITH_TYPE_TAG,
+        RECORDER_COMPRESSION_SETTINGS_TAG,
+        RECORDER_RECORD_TYPES_TAG,
+        RECORDER_ROS2_TYPES_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     if (YamlReader::is_tag_present(yml, RECORDER_OUTPUT_TAG))
     {
         auto output_yml = YamlReader::get_value_in_tag(yml, RECORDER_OUTPUT_TAG);
+
+        static const std::set<TagType> output_tags{
+            RECORDER_OUTPUT_PATH_FILE_TAG,
+            RECORDER_OUTPUT_FILE_NAME_TAG,
+            RECORDER_OUTPUT_TIMESTAMP_FORMAT_TAG,
+            RECORDER_OUTPUT_LOCAL_TIMESTAMP_TAG,
+            RECORDER_OUTPUT_SAFETY_MARGIN_TAG,
+            RECORDER_OUTPUT_RESOURCE_LIMITS_TAG};
+
+        YamlValidator::validate_tags(output_yml, output_tags);
 
         /////
         // Get optional file path
@@ -256,6 +288,13 @@ void RecorderConfiguration::load_recorder_configuration_(
         if (YamlReader::is_tag_present(output_yml, RECORDER_OUTPUT_RESOURCE_LIMITS_TAG))
         {
             auto resource_limits_yml = YamlReader::get_value_in_tag(output_yml, RECORDER_OUTPUT_RESOURCE_LIMITS_TAG);
+
+            static const std::set<TagType> resource_limits_tags{
+                RECORDER_OUTPUT_RESOURCE_LIMITS_FILE_ROTATION_TAG,
+                RECORDER_OUTPUT_RESOURCE_LIMITS_MAX_FILE_SIZE_TAG,
+                RECORDER_OUTPUT_RESOURCE_LIMITS_MAX_SIZE_TAG};
+
+            YamlValidator::validate_tags(resource_limits_yml, resource_limits_tags);
 
             /////
             // Get optional file rotation
@@ -337,10 +376,60 @@ void RecorderConfiguration::load_recorder_configuration_(
     }
 }
 
+void RecorderConfiguration::load_output_configuration_(
+        const Yaml& yml,
+        const YamlReaderVersion& version)
+{
+    static const std::set<TagType> tags{
+        RECORDER_OUTPUT_PATH_FILE_TAG,
+        RECORDER_OUTPUT_FILE_NAME_TAG,
+        RECORDER_OUTPUT_TIMESTAMP_FORMAT_TAG,
+        RECORDER_OUTPUT_LOCAL_TIMESTAMP_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
+    /////
+    // Get optional file path
+    if (YamlReader::is_tag_present(yml, RECORDER_OUTPUT_PATH_FILE_TAG))
+    {
+        output_filepath = YamlReader::get<std::string>(yml, RECORDER_OUTPUT_PATH_FILE_TAG, version);
+    }
+
+    /////
+    // Get optional file name
+    if (YamlReader::is_tag_present(yml, RECORDER_OUTPUT_FILE_NAME_TAG))
+    {
+        output_filename = YamlReader::get<std::string>(yml, RECORDER_OUTPUT_FILE_NAME_TAG, version);
+    }
+
+    /////
+    // Get optional timestamp format
+    if (YamlReader::is_tag_present(yml, RECORDER_OUTPUT_TIMESTAMP_FORMAT_TAG))
+    {
+        output_timestamp_format = YamlReader::get<std::string>(yml, RECORDER_OUTPUT_TIMESTAMP_FORMAT_TAG, version);
+    }
+
+    /////
+    // Get optional timestamp format
+    if (YamlReader::is_tag_present(yml, RECORDER_OUTPUT_LOCAL_TIMESTAMP_TAG))
+    {
+        output_local_timestamp = YamlReader::get<bool>(yml, RECORDER_OUTPUT_LOCAL_TIMESTAMP_TAG, version);
+    }
+}
+
 void RecorderConfiguration::load_controller_configuration_(
         const Yaml& yml,
         const YamlReaderVersion& version)
 {
+    static const std::set<TagType> tags{
+        RECORDER_REMOTE_CONTROLLER_ENABLE_TAG,
+        DOMAIN_ID_TAG,
+        RECORDER_REMOTE_CONTROLLER_INITIAL_STATE_TAG,
+        RECORDER_REMOTE_CONTROLLER_COMMAND_TOPIC_NAME_TAG,
+        RECORDER_REMOTE_CONTROLLER_STATUS_TOPIC_NAME_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     // Get optional enable remote controller
     if (YamlReader::is_tag_present(yml, RECORDER_REMOTE_CONTROLLER_ENABLE_TAG))
     {
@@ -358,8 +447,7 @@ void RecorderConfiguration::load_controller_configuration_(
     if (YamlReader::is_tag_present(yml, RECORDER_REMOTE_CONTROLLER_INITIAL_STATE_TAG))
     {
         // Convert to enum and check valid wherever used to avoid mcap library dependency in YAML module
-        initial_state = YamlReader::get<std::string>(yml,
-                        RECORDER_REMOTE_CONTROLLER_INITIAL_STATE_TAG, version);
+        initial_state = YamlReader::get<std::string>(yml, RECORDER_REMOTE_CONTROLLER_INITIAL_STATE_TAG, version);
         // Case insensitive
         eprosima::utils::to_uppercase(initial_state);
     }
@@ -383,6 +471,16 @@ void RecorderConfiguration::load_specs_configuration_(
         const Yaml& yml,
         const YamlReaderVersion& version)
 {
+    static const std::set<TagType> tags{
+        NUMBER_THREADS_TAG,
+        SPECS_QOS_TAG,
+        RECORDER_SPECS_MAX_PENDING_SAMPLES_TAG,
+        RECORDER_SPECS_CLEANUP_PERIOD_TAG,
+        LOG_CONFIGURATION_TAG,
+        MONITOR_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     // Get number of threads
     if (YamlReader::is_tag_present(yml, NUMBER_THREADS_TAG))
     {
@@ -393,7 +491,7 @@ void RecorderConfiguration::load_specs_configuration_(
     // Get optional Topic QoS
     if (YamlReader::is_tag_present(yml, SPECS_QOS_TAG))
     {
-        YamlReader::fill<TopicQoS>(topic_qos, YamlReader::get_value_in_tag(yml, SPECS_QOS_TAG), version);
+        topic_qos = YamlReader::get<TopicQoS>(yml, SPECS_QOS_TAG, version);
         TopicQoS::default_topic_qos.set_value(topic_qos);
     }
 
@@ -401,6 +499,7 @@ void RecorderConfiguration::load_specs_configuration_(
     if (YamlReader::is_tag_present(yml, RECORDER_SPECS_MAX_PENDING_SAMPLES_TAG))
     {
         max_pending_samples = YamlReader::get<int>(yml, RECORDER_SPECS_MAX_PENDING_SAMPLES_TAG, version);
+
         if (max_pending_samples < -1)
         {
             throw eprosima::utils::ConfigurationException(
@@ -434,6 +533,18 @@ void RecorderConfiguration::load_dds_configuration_(
         const Yaml& yml,
         const YamlReaderVersion& version)
 {
+    static const std::set<TagType> tags{
+        DOMAIN_ID_TAG,
+        WHITELIST_INTERFACES_TAG,
+        TRANSPORT_DESCRIPTORS_TRANSPORT_TAG,
+        IGNORE_PARTICIPANT_FLAGS_TAG,
+        ALLOWLIST_TAG,
+        BLOCKLIST_TAG,
+        TOPICS_TAG,
+        BUILTIN_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     // Get optional DDS domain
     if (YamlReader::is_tag_present(yml, DOMAIN_ID_TAG))
     {

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -23,9 +23,11 @@
 #include <cpp_utils/utils.hpp>
 
 #include <ddspipe_core/configuration/DdsPipeLogConfiguration.hpp>
+#include <ddspipe_core/types/dds/DomainId.hpp>
 #include <ddspipe_core/types/dynamic_types/types.hpp>
 #include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
+
 #include <ddspipe_participants/types/address/Address.hpp>
 
 #include <ddspipe_yaml/yaml_configuration_tags.hpp>

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReader_configuration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReader_configuration.cpp
@@ -1,0 +1,60 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file YamlReader_configuration.cpp
+ *
+ * Use this file to define tailored validation methods for the DDS Recorder.
+ * The methods are already implemented in the DDS Pipe, but they can be overridden here to provide specific validation.
+ *
+ * The namespace must be the same as the DDS Pipe's YamlReader class.
+ *
+ * NOTE: Overriding the same validate method in the DDS Recorder and the DDS Replayer would give conflicts. The
+ * functions that need to be overridden in both are left commented in both until the DDS Recorder and the DDS Replayer
+ * are split up into different products.
+ */
+
+#include <set>
+
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
+
+#include <ddspipe_yaml/YamlValidator.hpp>
+#include <ddspipe_yaml/yaml_configuration_tags.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace yaml {
+
+// template <>
+// bool YamlValidator::validate<core::types::TopicQoS>(
+//         const Yaml& yml,
+//         const YamlReaderVersion& /* version */)
+// {
+//     // The DDS Pipe's QOS_MAX_TX_RATE is invalid in the DDS Recorder.
+//     static const std::set<TagType> tags{
+//         QOS_TRANSIENT_TAG,
+//         QOS_RELIABLE_TAG,
+//         QOS_OWNERSHIP_TAG,
+//         QOS_PARTITION_TAG,
+//         QOS_HISTORY_DEPTH_TAG,
+//         QOS_KEYED_TAG,
+//         QOS_MAX_RX_RATE_TAG,
+//         QOS_DOWNSAMPLING_TAG};
+
+//     return YamlValidator::validate_tags(yml, tags);
+// }
+
+} /* namespace yaml */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddsrecorder_yaml/src/cpp/replayer/CommandlineArgsReplayer.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/CommandlineArgsReplayer.cpp
@@ -20,10 +20,9 @@ namespace yaml {
 
 CommandlineArgsReplayer::CommandlineArgsReplayer()
 {
-    log_filter[utils::VerbosityKind::Info].set_value("DDSREPLAYER", utils::FuzzyLevelValues::fuzzy_level_default);
-    log_filter[utils::VerbosityKind::Warning].set_value("DDSREPLAYER",
-            utils::FuzzyLevelValues::fuzzy_level_default);
-    log_filter[utils::VerbosityKind::Error].set_value("", utils::FuzzyLevelValues::fuzzy_level_default);
+    log_filter.info.set_value("DDSREPLAYER", utils::FuzzyLevelValues::fuzzy_level_default);
+    log_filter.warning.set_value("DDSREPLAYER", utils::FuzzyLevelValues::fuzzy_level_default);
+    log_filter.error.set_value("", utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool CommandlineArgsReplayer::is_valid(

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#include <set>
+
 #include <cpp_utils/utils.hpp>
 
 #include <ddspipe_core/configuration/DdsPipeLogConfiguration.hpp>
@@ -29,6 +31,7 @@
 #include <ddspipe_yaml/yaml_configuration_tags.hpp>
 #include <ddspipe_yaml/Yaml.hpp>
 #include <ddspipe_yaml/YamlManager.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
 
 #include <ddsrecorder_yaml/replayer/yaml_configuration_tags.hpp>
 #include <ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp>
@@ -66,6 +69,13 @@ void ReplayerConfiguration::load_ddsreplayer_configuration_(
     try
     {
         YamlReaderVersion version = LATEST;
+
+        static const std::set<TagType> tags{
+            REPLAYER_REPLAY_TAG,
+            SPECS_TAG,
+            REPLAYER_DDS_TAG};
+
+        YamlValidator::validate_tags(yml, tags);
 
         /////
         // Get optional Replayer configuration options
@@ -165,6 +175,16 @@ void ReplayerConfiguration::load_replay_configuration_(
         const Yaml& yml,
         const YamlReaderVersion& version)
 {
+    static const std::set<TagType> tags{
+        REPLAYER_REPLAY_INPUT_TAG,
+        REPLAYER_REPLAY_BEGIN_TAG,
+        REPLAYER_REPLAY_END_TAG,
+        REPLAYER_REPLAY_RATE_TAG,
+        REPLAYER_REPLAY_START_TIME_TAG,
+        REPLAYER_REPLAY_TYPES_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     // Get optional input_file
     if (YamlReader::is_tag_present(yml, REPLAYER_REPLAY_INPUT_TAG))
     {
@@ -214,6 +234,14 @@ void ReplayerConfiguration::load_specs_configuration_(
         const Yaml& yml,
         const YamlReaderVersion& version)
 {
+    static const std::set<TagType> tags{
+        NUMBER_THREADS_TAG,
+        SPECS_QOS_TAG,
+        WAIT_ALL_ACKED_TIMEOUT_TAG,
+        LOG_CONFIGURATION_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     // Get number of threads
     if (YamlReader::is_tag_present(yml, NUMBER_THREADS_TAG))
     {
@@ -224,7 +252,7 @@ void ReplayerConfiguration::load_specs_configuration_(
     // Get optional Topic QoS
     if (YamlReader::is_tag_present(yml, SPECS_QOS_TAG))
     {
-        YamlReader::fill<TopicQoS>(topic_qos, YamlReader::get_value_in_tag(yml, SPECS_QOS_TAG), version);
+        topic_qos = YamlReader::get<TopicQoS>(yml, SPECS_QOS_TAG, version);
         TopicQoS::default_topic_qos.set_value(topic_qos);
     }
 
@@ -248,6 +276,17 @@ void ReplayerConfiguration::load_dds_configuration_(
         const Yaml& yml,
         const YamlReaderVersion& version)
 {
+    static const std::set<TagType> tags{
+        DOMAIN_ID_TAG,
+        WHITELIST_INTERFACES_TAG,
+        TRANSPORT_DESCRIPTORS_TRANSPORT_TAG,
+        IGNORE_PARTICIPANT_FLAGS_TAG,
+        ALLOWLIST_TAG,
+        BLOCKLIST_TAG,
+        TOPICS_TAG};
+
+    YamlValidator::validate_tags(yml, tags);
+
     // Get optional DDS domain
     if (YamlReader::is_tag_present(yml, DOMAIN_ID_TAG))
     {

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReader_configuration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReader_configuration.cpp
@@ -1,0 +1,59 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file YamlReader_configuration.cpp
+ *
+ * Use this file to define tailored validation methods for the DDS Replayer.
+ * The methods are already implemented in the DDS Pipe, but they can be overridden here to provide specific validation.
+ *
+ * The namespace must be the same as the DDS Pipe's YamlReader class.
+ *
+ * NOTE: Overriding the same validate method in the DDS Recorder and the DDS Replayer would give conflicts. The
+ * functions that need to be overridden in both are left commented in both until the DDS Recorder and the DDS Replayer
+ * are split up into different products.
+ */
+
+#include <set>
+
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
+
+#include <ddspipe_yaml/YamlValidator.hpp>
+#include <ddspipe_yaml/yaml_configuration_tags.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace yaml {
+
+// template <>
+// bool YamlValidator::validate<core::types::TopicQoS>(
+//         const Yaml& yml,
+//         const YamlReaderVersion& /* version */)
+// {
+//     // The DDS Pipe's QOS_MAX_RX_RATE and QOS_DOWNSAMPLING are invalid in the DDS Replayer.
+//     static const std::set<TagType> tags{
+//         QOS_TRANSIENT_TAG,
+//         QOS_RELIABLE_TAG,
+//         QOS_OWNERSHIP_TAG,
+//         QOS_PARTITION_TAG,
+//         QOS_HISTORY_DEPTH_TAG,
+//         QOS_KEYED_TAG,
+//         QOS_MAX_TX_RATE_TAG};
+
+//     return YamlValidator::validate_tags(yml, tags);
+// }
+
+} /* namespace yaml */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddsrecorder_yaml/test/YamlGetConfigurationDdsRecorderReplayerTest.cpp
+++ b/ddsrecorder_yaml/test/YamlGetConfigurationDdsRecorderReplayerTest.cpp
@@ -40,7 +40,7 @@ TEST(YamlGetConfigurationDdsRecorderReplayerTest, get_ddsrecorder_configuration_
     CommandlineArgsRecorder commandline_args;
 
     // Setting CommandLine arguments as if configured from CommandLine
-    commandline_args.log_filter[eprosima::utils::VerbosityKind::Warning].set_value("DDSRECORDER|DDSPIPE|DEBUG");
+    commandline_args.log_filter.warning.set_value("DDSRECORDER|DDSPIPE|DEBUG");
 
     const char* yml_str =
             R"(
@@ -62,14 +62,11 @@ TEST(YamlGetConfigurationDdsRecorderReplayerTest, get_ddsrecorder_configuration_
     ASSERT_TRUE(configuration.ddspipe_configuration.log_configuration.is_valid(error_msg));
     ASSERT_EQ(configuration.ddspipe_configuration.log_configuration.verbosity.get_value(), utils::VerbosityKind::Info);
     ASSERT_EQ(
-        configuration.ddspipe_configuration.log_configuration.filter[utils::VerbosityKind::Error].get_value(),
-        "DEBUG");
+        configuration.ddspipe_configuration.log_configuration.filter.error.get_value(), "DEBUG");
     ASSERT_EQ(
-        configuration.ddspipe_configuration.log_configuration.filter[utils::VerbosityKind::Warning].get_value(),
-        "DDSRECORDER|DDSPIPE|DEBUG");
+        configuration.ddspipe_configuration.log_configuration.filter.warning.get_value(), "DDSRECORDER|DDSPIPE|DEBUG");
     ASSERT_EQ(
-        configuration.ddspipe_configuration.log_configuration.filter[utils::VerbosityKind::Info].get_value(),
-        "DDSRECORDER");
+        configuration.ddspipe_configuration.log_configuration.filter.info.get_value(), "DDSRECORDER");
 }
 
 /**
@@ -87,7 +84,7 @@ TEST(YamlGetConfigurationDdsRecorderReplayerTest, get_ddsreplayer_configuration_
     CommandlineArgsReplayer commandline_args;
 
     // Setting CommandLine arguments as if configured from CommandLine
-    commandline_args.log_filter[eprosima::utils::VerbosityKind::Warning].set_value("DDSREPLAYER|DDSPIPE|DEBUG");
+    commandline_args.log_filter.warning.set_value("DDSREPLAYER|DDSPIPE|DEBUG");
 
     const char* yml_str =
             R"(
@@ -109,14 +106,11 @@ TEST(YamlGetConfigurationDdsRecorderReplayerTest, get_ddsreplayer_configuration_
     ASSERT_TRUE(configuration.ddspipe_configuration.log_configuration.is_valid(error_msg));
     ASSERT_EQ(configuration.ddspipe_configuration.log_configuration.verbosity.get_value(), utils::VerbosityKind::Info);
     ASSERT_EQ(
-        configuration.ddspipe_configuration.log_configuration.filter[utils::VerbosityKind::Error].get_value(),
-        "DEBUG");
+        configuration.ddspipe_configuration.log_configuration.filter.error.get_value(), "DEBUG");
     ASSERT_EQ(
-        configuration.ddspipe_configuration.log_configuration.filter[utils::VerbosityKind::Warning].get_value(),
-        "DDSREPLAYER|DDSPIPE|DEBUG");
+        configuration.ddspipe_configuration.log_configuration.filter.warning.get_value(), "DDSREPLAYER|DDSPIPE|DEBUG");
     ASSERT_EQ(
-        configuration.ddspipe_configuration.log_configuration.filter[utils::VerbosityKind::Info].get_value(),
-        "DDSREPLAYER");
+        configuration.ddspipe_configuration.log_configuration.filter.info.get_value(), "DDSREPLAYER");
 }
 
 int main(

--- a/ddsreplayer/src/cpp/main.cpp
+++ b/ddsreplayer/src/cpp/main.cpp
@@ -108,6 +108,14 @@ std::unique_ptr<eprosima::utils::event::PeriodicEventHandler> create_periodic_ha
     return std::make_unique<eprosima::utils::event::PeriodicEventHandler>(periodic_callback, reload_time);
 }
 
+int exit(const ProcessReturnCode& code)
+{
+    // Delete the consumers before closing
+    eprosima::utils::Log::ClearConsumers();
+
+    return static_cast<int>(code);
+}
+
 int main(
         int argc,
         char** argv)
@@ -121,15 +129,15 @@ int main(
 
     if (arg_parse_result == ProcessReturnCode::help_argument)
     {
-        return static_cast<int>(ProcessReturnCode::success);
+        return exit(ProcessReturnCode::success);
     }
     else if (arg_parse_result == ProcessReturnCode::version_argument)
     {
-        return static_cast<int>(ProcessReturnCode::success);
+        return exit(ProcessReturnCode::success);
     }
     else if (arg_parse_result != ProcessReturnCode::success)
     {
-        return static_cast<int>(arg_parse_result);
+        return exit(arg_parse_result);
     }
 
     // Check file is in args, else get the default file
@@ -153,7 +161,7 @@ int main(
             EPROSIMA_LOG_ERROR(
                 DDSREPLAYER_ARGS,
                 "File '" << commandline_args.file_path << "' does not exist or it is not accessible.");
-            return static_cast<int>(ProcessReturnCode::required_argument_failed);
+            return exit(ProcessReturnCode::required_argument_failed);
         }
     }
 
@@ -215,7 +223,7 @@ int main(
                     EPROSIMA_LOG_ERROR(
                         DDSREPLAYER_ARGS,
                         "File '" << commandline_args.input_file << "' does not exist or it is not accessible.");
-                    return static_cast<int>(ProcessReturnCode::required_argument_failed);
+                    return exit(ProcessReturnCode::required_argument_failed);
                 }
             }
             else
@@ -224,7 +232,7 @@ int main(
                     DDSREPLAYER_ARGS,
                     "An input MCAP file must be provided through argument '-i' / '--input-file' " <<
                         "or under 'input-file' YAML tag.");
-                return static_cast<int>(ProcessReturnCode::required_argument_failed);
+                return exit(ProcessReturnCode::required_argument_failed);
             }
         }
         else
@@ -283,7 +291,7 @@ int main(
         if (!read_success)
         {
             // An exception was captured in the MCAP reading thread
-            return static_cast<int>(ProcessReturnCode::execution_failed);
+            return exit(ProcessReturnCode::execution_failed);
         }
 
         logUser(DDSREPLAYER_EXECUTION, "Stopping DDS Replayer.");
@@ -296,23 +304,17 @@ int main(
                 "Error Loading DDS Replayer Configuration from file " << commandline_args.file_path <<
                 ". Error message:\n " <<
                 e.what());
-        return static_cast<int>(ProcessReturnCode::execution_failed);
+        return exit(ProcessReturnCode::execution_failed);
     }
     catch (const eprosima::utils::InitializationException& e)
     {
         EPROSIMA_LOG_ERROR(DDSREPLAYER_ERROR,
                 "Error Initializing DDS Replayer. Error message:\n " <<
                 e.what());
-        return static_cast<int>(ProcessReturnCode::execution_failed);
+        return exit(ProcessReturnCode::execution_failed);
     }
 
     logUser(DDSREPLAYER_EXECUTION, "Finishing DDS Replayer execution correctly.");
 
-    // Force print every log before closing
-    eprosima::utils::Log::Flush();
-
-    // Delete the consumers before closing
-    eprosima::utils::Log::ClearConsumers();
-
-    return static_cast<int>(ProcessReturnCode::success);
+    return exit(ProcessReturnCode::success);
 }

--- a/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
@@ -252,16 +252,16 @@ ProcessReturnCode parse_arguments(
                     break;
 
                 case optionIndex::ACTIVATE_DEBUG:
-                    commandline_args.log_filter[utils::VerbosityKind::Error].set_value("");
-                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("DDSREPLAYER");
-                    commandline_args.log_filter[utils::VerbosityKind::Info].set_value("DDSREPLAYER");
+                    commandline_args.log_filter.error.set_value("");
+                    commandline_args.log_filter.warning.set_value("DDSREPLAYER");
+                    commandline_args.log_filter.info.set_value("DDSREPLAYER");
                     commandline_args.log_verbosity = utils::VerbosityKind::Info;
                     break;
 
                 case optionIndex::LOG_FILTER:
-                    commandline_args.log_filter[utils::VerbosityKind::Error].set_value(opt.arg);
-                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value(opt.arg);
-                    commandline_args.log_filter[utils::VerbosityKind::Info].set_value(opt.arg);
+                    commandline_args.log_filter.error.set_value(opt.arg);
+                    commandline_args.log_filter.warning.set_value(opt.arg);
+                    commandline_args.log_filter.info.set_value(opt.arg);
                     break;
 
                 case optionIndex::LOG_VERBOSITY:

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -5,3 +5,20 @@
 ###################
 Forthcoming Version
 ###################
+
+This release includes the following **Recording features**:
+
+* :ref:`Resource Limits <recorder_specs_logging>`.
+
+This release includes the following **DDS Recorder tool configuration features**:
+
+* New yaml validation to log configuration errors.
+
+This release includes the following **DDS Replayer tool configuration features**:
+
+* New yaml validation to log configuration errors.
+
+This release includes the following **DDS Recorder & Replay internal adjustments**:
+
+* Avoid parsing configuration files twice on start-up.
+* Ensure resources are freed up properly when an error occurs.


### PR DESCRIPTION
In this version, the DDS Recorder and the DDS Replayer throw a warning when a YAML tag is ignored to prevent typos, misplacements, and wrong configurations.

Merge after:
- https://github.com/eProsima/DDS-Pipe/pull/85