### PR TITLE
Change default log configuration filter

### DIFF
--- a/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
@@ -251,7 +251,7 @@ ProcessReturnCode parse_arguments(
 
                 case optionIndex::ACTIVATE_DEBUG:
                     commandline_args.log_filter[utils::VerbosityKind::Error].set_value("");
-                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("(DDSRECORDER|DDSPIPE)");
+                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("DDSRECORDER");
                     commandline_args.log_filter[utils::VerbosityKind::Info].set_value("DDSRECORDER");
                     commandline_args.log_verbosity = utils::VerbosityKind::Info;
                     break;

--- a/ddsrecorder_yaml/src/cpp/recorder/CommandlineArgsRecorder.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/CommandlineArgsRecorder.cpp
@@ -21,7 +21,7 @@ namespace yaml {
 CommandlineArgsRecorder::CommandlineArgsRecorder()
 {
     log_filter[utils::VerbosityKind::Info].set_value("DDSRECORDER", utils::FuzzyLevelValues::fuzzy_level_default);
-    log_filter[utils::VerbosityKind::Warning].set_value("DDSRECORDER|DDSPIPE",
+    log_filter[utils::VerbosityKind::Warning].set_value("DDSRECORDER",
             utils::FuzzyLevelValues::fuzzy_level_default);
     log_filter[utils::VerbosityKind::Error].set_value("", utils::FuzzyLevelValues::fuzzy_level_default);
 }

--- a/ddsrecorder_yaml/src/cpp/replayer/CommandlineArgsReplayer.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/CommandlineArgsReplayer.cpp
@@ -21,7 +21,7 @@ namespace yaml {
 CommandlineArgsReplayer::CommandlineArgsReplayer()
 {
     log_filter[utils::VerbosityKind::Info].set_value("DDSREPLAYER", utils::FuzzyLevelValues::fuzzy_level_default);
-    log_filter[utils::VerbosityKind::Warning].set_value("DDSREPLAYER|DDSPIPE",
+    log_filter[utils::VerbosityKind::Warning].set_value("DDSREPLAYER",
             utils::FuzzyLevelValues::fuzzy_level_default);
     log_filter[utils::VerbosityKind::Error].set_value("", utils::FuzzyLevelValues::fuzzy_level_default);
 }

--- a/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
@@ -253,7 +253,7 @@ ProcessReturnCode parse_arguments(
 
                 case optionIndex::ACTIVATE_DEBUG:
                     commandline_args.log_filter[utils::VerbosityKind::Error].set_value("");
-                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("(DDSREPLAYER|DDSPIPE)");
+                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("DDSREPLAYER");
                     commandline_args.log_filter[utils::VerbosityKind::Info].set_value("DDSREPLAYER");
                     commandline_args.log_verbosity = utils::VerbosityKind::Info;
                     break;

--- a/docs/rst/recording/usage/configuration.rst
+++ b/docs/rst/recording/usage/configuration.rst
@@ -569,7 +569,7 @@ Logging
 Under the ``logging`` tag, users can configure the type of logs to display and filter the logs based on their content and category.
 When configuring the verbosity to ``info``, all types of logs, including informational messages, warnings, and errors, will be displayed.
 Conversely, setting it to ``warning`` will only show warnings and errors, while choosing ``error`` will exclusively display errors.
-By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``DDSPIPE|DDSRECORDER`` and informational messages from the ``DDSRECORDER`` category.
+By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``DDSRECORDER`` and informational messages from the ``DDSRECORDER`` category.
 
 .. note::
 
@@ -599,7 +599,7 @@ By default, the filter allows all errors to be displayed, while selectively perm
           or message of the logs.
         - *string*
         - info : ``DDSRECORDER`` |br|
-          warning : ``DDSPIPE|DDSRECORDER`` |br|
+          warning : ``DDSRECORDER`` |br|
           error : ``""``
         - Regex string
 

--- a/docs/rst/replaying/usage/configuration.rst
+++ b/docs/rst/replaying/usage/configuration.rst
@@ -398,7 +398,7 @@ Logging
 Under the ``logging`` tag, users can configure the type of logs to display and filter the logs based on their content and category.
 When configuring the verbosity to ``info``, all types of logs, including informational messages, warnings, and errors, will be displayed.
 Conversely, setting it to ``warning`` will only show warnings and errors, while choosing ``error`` will exclusively display errors.
-By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``DDSPIPE|DDSREPLAYER`` and informational messages from the ``DDSREPLAYER`` category.
+By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``DDSREPLAYER`` and informational messages from the ``DDSREPLAYER`` category.
 
 .. code-block:: yaml
 
@@ -437,7 +437,7 @@ By default, the filter allows all errors to be displayed, while selectively perm
           or message of the logs.
         - *string*
         - info : ``DDSREPLAYER`` |br|
-          warning : ``DDSPIPE|DDSREPLAYER`` |br|
+          warning : ``DDSREPLAYER`` |br|
           error : ``""``
         - Regex string
 .. note::


### PR DESCRIPTION
Change default log filter configuration in DDSRecorder tool to:
          - info : ``DDSRECORDER``
          - warning : ``DDSRECORDER``
          - error : ``""``
and DDSReplayer tool to:
          - info : ``DDSREPLAYER``
          - warning : ``DDSREPLAYER``
          - error : ``""``