### PR TITLE
Abort when the max_file_size is too small

### DIFF
--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/mcap/McapWriter.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/mcap/McapWriter.hpp
@@ -203,6 +203,9 @@ protected:
     // Whether the writer can write to the MCAP library
     bool enabled_{false};
 
+    // Whether the output file is open
+    bool opened_{false};
+
     // Track the size of the current MCAP file
     McapSizeTracker size_tracker_;
 

--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/mcap/impl/McapWriter.ipp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/mcap/impl/McapWriter.ipp
@@ -49,6 +49,12 @@ void McapWriter::write(
             on_disk_full_();
         }
     }
+    catch (const FullDiskException& e)
+    {
+        logError(DDSRECORDER_MCAP_HANDLER,
+                "FAIL_MCAP_WRITE | Disk is full. Error message:\n " << e.what());
+        on_disk_full_();
+    }
 }
 
 } /* namespace participants */

--- a/ddsrecorder_participants/src/cpp/recorder/mcap/McapWriter.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/mcap/McapWriter.cpp
@@ -145,6 +145,12 @@ void McapWriter::update_dynamic_types(
             on_disk_full_();
         }
     }
+    catch (const FullDiskException& e)
+    {
+        logError(DDSRECORDER_MCAP_HANDLER,
+                "FAIL_MCAP_WRITE | Disk is full. Error message:\n " << e.what());
+        on_disk_full_();
+    }
 
     dynamic_types_payload_.reset(const_cast<fastrtps::rtps::SerializedPayload_t*>(&dynamic_types_payload));
     file_tracker_->set_current_file_size(size_tracker_.get_potential_mcap_size());
@@ -168,6 +174,10 @@ void McapWriter::open_new_file_nts_(
         throw FullDiskException(
                   "The minimum MCAP size (" + utils::from_bytes(min_file_size) + ") is greater than the maximum MCAP "
                   "size (" + utils::from_bytes(configuration_.max_file_size) + ").");
+    }
+    catch (const utils::InconsistencyException& e)
+    {
+        throw FullDiskException(e.what());
     }
 
     const auto filename = file_tracker_->get_current_filename();


### PR DESCRIPTION
This PR fixes two minor bugs:
1. Before, when the size of a dataless MCAP file was larger than the `max_file_size`, the `McapWriter` was not capturing the error correctly and kept trying to write data to it. Now, the `McapWriter` aborts as if the disk was full.
2. Before, the `McapWriter` attempted to write to the MCAP file even after the file was closed. Now, if the `McapWriter` fails to open a new file, it will never try to write to it.