### PR TITLE
Update artifact name for flaky tests

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -252,10 +252,14 @@ jobs:
           secret_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compile and run tests
-        uses: eProsima/eProsima-CI/multiplatform/colcon_build_test_flaky@v0
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build_test@v0
         with:
           packages_names: ${{ env.code_packages_names }}
+          cmake_args: -DBUILD_TESTS=ON
           workspace_dependencies: './install'
+          ctest_args: --label-regex "xfail"
+          colcon_meta_file: ./src/.github/workflows/configurations/${{ runner.os }}/colcon.meta
+          test_report_artifact: test_report_flaky${{ inputs.dependencies_artifact_postfix }}_${{ inputs.custom_version_build }}
 
 
 #####################################################################


### PR DESCRIPTION
Flaky tests failed as their generated artifacts had the same names for runs with Fast DDS v2 and Fast DDS v3.
