### PR TITLE
[22666] Fix CI windows vcpkg installation lz4 zstd

### DIFF
--- a/.github/actions/install_mcap_dependencies/action.yml
+++ b/.github/actions/install_mcap_dependencies/action.yml
@@ -32,7 +32,7 @@ runs:
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgDirectory: '${{ github.workspace }}/vcpkg'
-        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
+        vcpkgGitCommitId: '6f29f12e82a8293156836ad81cc9bf5af41fe836'
 
     - name: Install lz4 and zstd
       if: runner.os == 'Windows'


### PR DESCRIPTION
The record&replay CI is currently failing on action install_mcap_dependencies in windows in step [Install vcpkg](https://github.com/eProsima/DDS-Record-Replay/blob/b933de7c8d1a924c18b61383121e3bfbced870e0/.github/actions/install_mcap_dependencies/action.yml#L30)