### PR TITLE
[#24280] Add `--domain` support

### DIFF
--- a/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <iostream>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -121,7 +122,7 @@ const option::Descriptor usage[] = {
         "domain",
         Arg::Numeric,
         "  \t--domain\t  \t" \
-        "Set the domain (0-255) to record on. " \
+        "Set the domain (0-232) to record on. " \
         "[Default = 0]."
     },
 
@@ -272,8 +273,34 @@ ProcessReturnCode parse_arguments(
                     break;
 
                 case optionIndex::DOMAIN:
-                    commandline_args.domain.set_value(std::stoi(opt.arg));
-                    break;
+                {
+                    const auto max_domain_id = static_cast<long>(ddspipe::core::types::DomainId::MAX_DOMAIN_ID);
+                    long domain_value = 0;
+
+                    try
+                    {
+                        domain_value = std::stol(opt.arg);
+                    }
+                    catch (const std::exception&)
+                    {
+                        EPROSIMA_LOG_ERROR(
+                            DDSRECORDER_ARGS,
+                            "Domain ID must be between 0 and " << max_domain_id << ".");
+                        return ProcessReturnCode::incorrect_argument;
+                    }
+
+                    if (domain_value < 0 || domain_value > max_domain_id)
+                    {
+                        EPROSIMA_LOG_ERROR(
+                            DDSRECORDER_ARGS,
+                            "Domain ID must be between 0 and " << max_domain_id << ".");
+                        return ProcessReturnCode::incorrect_argument;
+                    }
+
+                    commandline_args.domain.set_value(
+                        static_cast<ddspipe::core::types::DomainIdType>(domain_value));
+                }
+                break;
 
                 case optionIndex::LOG_FILTER:
                     commandline_args.log_filter[utils::VerbosityKind::Error].set_value(opt.arg);

--- a/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
@@ -114,6 +114,17 @@ const option::Descriptor usage[] = {
         "Value 0 does not set maximum. [Default: 0]."
     },
 
+    {
+        optionIndex::DOMAIN,
+        0,
+        "",
+        "domain",
+        Arg::Numeric,
+        "  \t--domain\t  \t" \
+        "Set the domain (0-255) to record on. " \
+        "[Default = 0]."
+    },
+
     ////////////////////
     // Debug options
     {
@@ -258,6 +269,10 @@ ProcessReturnCode parse_arguments(
 
                 case optionIndex::TIMEOUT:
                     commandline_args.timeout = std::stol(opt.arg) * 1000; // pass to milliseconds
+                    break;
+
+                case optionIndex::DOMAIN:
+                    commandline_args.domain.set_value(std::stoi(opt.arg));
                     break;
 
                 case optionIndex::LOG_FILTER:

--- a/ddsrecorder/src/cpp/user_interface/arguments_configuration.hpp
+++ b/ddsrecorder/src/cpp/user_interface/arguments_configuration.hpp
@@ -100,6 +100,7 @@ enum optionIndex
     TIMEOUT,
     LOG_FILTER,
     LOG_VERBOSITY,
+    DOMAIN,
 };
 
 /**

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/CommandlineArgsRecorder.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/recorder/CommandlineArgsRecorder.hpp
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include <cpp_utils/types/Fuzzy.hpp>
+
 #include <ddspipe_core/configuration/CommandlineArgs.hpp>
+#include <ddspipe_core/types/dds/DomainId.hpp>
 
 #include <ddsrecorder_yaml/library/library_dll.h>
 
@@ -50,6 +53,9 @@ struct DDSRECORDER_YAML_DllAPI CommandlineArgsRecorder : public ddspipe::core::C
 
     // Maximum timeout
     utils::Duration_ms timeout{0};
+
+    // Domain
+    utils::Fuzzy<ddspipe::core::types::DomainId> domain{0, utils::FuzzyLevelValues::fuzzy_level_default};
 };
 
 } /* namespace yaml */

--- a/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/CommandlineArgsReplayer.hpp
+++ b/ddsrecorder_yaml/include/ddsrecorder_yaml/replayer/CommandlineArgsReplayer.hpp
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include <cpp_utils/types/Fuzzy.hpp>
+
 #include <ddspipe_core/configuration/CommandlineArgs.hpp>
+#include <ddspipe_core/types/dds/DomainId.hpp>
 
 #include <ddsrecorder_yaml/library/library_dll.h>
 
@@ -50,6 +53,9 @@ struct DDSRECORDER_YAML_DllAPI CommandlineArgsReplayer : public ddspipe::core::C
 
     // Input file path
     std::string input_file{""};
+
+    // Domain
+    utils::Fuzzy<ddspipe::core::types::DomainId> domain{0, utils::FuzzyLevelValues::fuzzy_level_default};
 };
 
 } /* namespace yaml */

--- a/ddsrecorder_yaml/src/cpp/recorder/CommandlineArgsRecorder.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/CommandlineArgsRecorder.cpp
@@ -29,9 +29,9 @@ CommandlineArgsRecorder::CommandlineArgsRecorder()
 bool CommandlineArgsRecorder::is_valid(
         utils::Formatter& error_msg) const noexcept
 {
-    if (domain.is_set() && (domain.get_value() < 0 || domain.get_value() > 255))
+    if (domain.is_set() && (domain.get_value() < 0 || domain.get_value() > 232))
     {
-        error_msg << "Domain ID must be between 0 and 255";
+        error_msg << "Domain ID must be between 0 and 232";
         return false;
     }
 

--- a/ddsrecorder_yaml/src/cpp/recorder/CommandlineArgsRecorder.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/CommandlineArgsRecorder.cpp
@@ -29,6 +29,12 @@ CommandlineArgsRecorder::CommandlineArgsRecorder()
 bool CommandlineArgsRecorder::is_valid(
         utils::Formatter& error_msg) const noexcept
 {
+    if (domain.is_set() && (domain.get_value() < 0 || domain.get_value() > 255))
+    {
+        error_msg << "Domain ID must be between 0 and 255";
+        return false;
+    }
+
     return ddspipe::core::CommandlineArgs::is_valid(error_msg);
 }
 

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -69,6 +69,24 @@ RecorderConfiguration::RecorderConfiguration(
 bool RecorderConfiguration::is_valid(
         utils::Formatter& error_msg) noexcept
 {
+    if (!dds_configuration)
+    {
+        error_msg << "DDS participant configuration is not initialized.";
+        return false;
+    }
+
+    if (dds_configuration->domain.domain_id > DomainId::MAX_DOMAIN_ID)
+    {
+        error_msg << "Domain ID must be between 0 and " << DomainId::MAX_DOMAIN_ID << ".";
+        return false;
+    }
+
+    if (enable_remote_controller && controller_domain.domain_id > DomainId::MAX_DOMAIN_ID)
+    {
+        error_msg << "Remote controller domain ID must be between 0 and " << DomainId::MAX_DOMAIN_ID << ".";
+        return false;
+    }
+
     if (!mcap_enabled && !sql_enabled)
     {
         error_msg << "At least one of MCAP or SQL libraries must be enabled.";

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -218,6 +218,12 @@ void RecorderConfiguration::load_ddsrecorder_configuration_(
         {
             ddspipe_configuration.log_configuration.set(args->log_verbosity);
             ddspipe_configuration.log_configuration.set(args->log_filter);
+
+            if (args->domain.is_set())
+            {
+                dds_configuration->domain = args->domain.get_value();
+                controller_domain = dds_configuration->domain;
+            }
         }
     }
     catch (const std::exception& e)

--- a/ddsrecorder_yaml/src/cpp/replayer/CommandlineArgsReplayer.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/CommandlineArgsReplayer.cpp
@@ -29,9 +29,9 @@ CommandlineArgsReplayer::CommandlineArgsReplayer()
 bool CommandlineArgsReplayer::is_valid(
         utils::Formatter& error_msg) const noexcept
 {
-    if (domain.is_set() && (domain.get_value() < 0 || domain.get_value() > 255))
+    if (domain.is_set() && (domain.get_value() < 0 || domain.get_value() > 232))
     {
-        error_msg << "Domain ID must be between 0 and 255";
+        error_msg << "Domain ID must be between 0 and 232";
         return false;
     }
 

--- a/ddsrecorder_yaml/src/cpp/replayer/CommandlineArgsReplayer.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/CommandlineArgsReplayer.cpp
@@ -29,6 +29,12 @@ CommandlineArgsReplayer::CommandlineArgsReplayer()
 bool CommandlineArgsReplayer::is_valid(
         utils::Formatter& error_msg) const noexcept
 {
+    if (domain.is_set() && (domain.get_value() < 0 || domain.get_value() > 255))
+    {
+        error_msg << "Domain ID must be between 0 and 255";
+        return false;
+    }
+
     return ddspipe::core::CommandlineArgs::is_valid(error_msg);
 }
 

--- a/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/replayer/YamlReaderConfiguration.cpp
@@ -151,6 +151,11 @@ void ReplayerConfiguration::load_ddsreplayer_configuration_(
         {
             ddspipe_configuration.log_configuration.set(args->log_verbosity);
             ddspipe_configuration.log_configuration.set(args->log_filter);
+
+            if (args->domain.is_set())
+            {
+                replayer_configuration->domain = args->domain.get_value();
+            }
         }
     }
     catch (const std::exception& e)

--- a/ddsreplayer/src/cpp/main.cpp
+++ b/ddsreplayer/src/cpp/main.cpp
@@ -56,7 +56,7 @@ std::unique_ptr<eprosima::utils::event::FileWatcherHandler> create_filewatcher(
     // WARNING: it is needed to pass file_path, as FileWatcher only retrieves file_name
     std::function<void(std::string)> filewatcher_callback =
             [&replayer, &file_path]
-                (std::string file_name)
+            (std::string file_name)
             {
                 logUser(
                     DDSREPLAYER_EXECUTION,
@@ -70,8 +70,8 @@ std::unique_ptr<eprosima::utils::event::FileWatcherHandler> create_filewatcher(
                 catch (const std::exception& e)
                 {
                     EPROSIMA_LOG_WARNING(DDSREPLAYER_EXECUTION,
-                            "Error reloading configuration file " << file_name << " with error: " <<
-                            e.what());
+                            "Error reloading configuration file " << file_name << " with error: "
+                                                                  << e.what());
                 }
             };
 
@@ -87,7 +87,7 @@ std::unique_ptr<eprosima::utils::event::PeriodicEventHandler> create_periodic_ha
     // Callback will reload configuration and pass it to DdsPipe
     std::function<void()> periodic_callback =
             [&replayer, &file_path]
-                ()
+            ()
             {
                 logUser(
                     DDSREPLAYER_EXECUTION,
@@ -101,8 +101,8 @@ std::unique_ptr<eprosima::utils::event::PeriodicEventHandler> create_periodic_ha
                 catch (const std::exception& e)
                 {
                     EPROSIMA_LOG_WARNING(DDSREPLAYER_EXECUTION,
-                            "Error reloading configuration file " << file_path << " with error: " <<
-                            e.what());
+                            "Error reloading configuration file " << file_path << " with error: "
+                                                                  << e.what());
                 }
             };
 
@@ -181,6 +181,22 @@ int main(
         // Load configuration from YAML
         eprosima::ddsrecorder::yaml::ReplayerConfiguration configuration(commandline_args.file_path, &commandline_args);
 
+        // Validate YAML domain bounds before creating DDS entities
+        if (!configuration.replayer_configuration)
+        {
+            throw eprosima::utils::ConfigurationException(
+                      eprosima::utils::Formatter()
+                          << "Invalid configuration: Replayer participant configuration is not initialized.");
+        }
+
+        if (configuration.replayer_configuration->domain.domain_id > eprosima::ddspipe::core::types::DomainId::
+                        MAX_DOMAIN_ID)
+        {
+            throw eprosima::utils::ConfigurationException(
+                      eprosima::utils::Formatter() << "Invalid configuration: Domain ID must be between 0 and "
+                                                   << eprosima::ddspipe::core::types::DomainId::MAX_DOMAIN_ID << ".");
+        }
+
         /////
         // Logging
         {
@@ -224,8 +240,8 @@ int main(
             {
                 EPROSIMA_LOG_ERROR(
                     DDSREPLAYER_ARGS,
-                    "An input file must be provided through argument '-i' / '--input-file' " <<
-                        "or under 'input-file' YAML tag.");
+                    "An input file must be provided through argument '-i' / '--input-file' "
+                        << "or under 'input-file' YAML tag.");
                 return static_cast<int>(ProcessReturnCode::required_argument_failed);
             }
         }
@@ -269,8 +285,8 @@ int main(
                     catch (const eprosima::utils::InconsistencyException& e)
                     {
                         EPROSIMA_LOG_ERROR(DDSREPLAYER_ERROR,
-                        "Error processing input file. Error message:\n " <<
-                            e.what());
+                        "Error processing input file. Error message:\n "
+                            << e.what());
                         read_success = false;
                     }
                     close_handler->simulate_event_occurred();
@@ -297,16 +313,16 @@ int main(
     catch (const eprosima::utils::ConfigurationException& e)
     {
         EPROSIMA_LOG_ERROR(DDSREPLAYER_ERROR,
-                "Error Loading DDS Replayer Configuration from file " << commandline_args.file_path <<
-                ". Error message:\n " <<
-                e.what());
+                "Error Loading DDS Replayer Configuration from file " << commandline_args.file_path
+                                                                      << ". Error message:\n "
+                                                                      << e.what());
         return static_cast<int>(ProcessReturnCode::execution_failed);
     }
     catch (const eprosima::utils::InitializationException& e)
     {
         EPROSIMA_LOG_ERROR(DDSREPLAYER_ERROR,
-                "Error Initializing DDS Replayer. Error message:\n " <<
-                e.what());
+                "Error Initializing DDS Replayer. Error message:\n "
+                << e.what());
         return static_cast<int>(ProcessReturnCode::execution_failed);
     }
 

--- a/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <iostream>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -119,7 +120,7 @@ const option::Descriptor usage[] = {
         "domain",
         Arg::Numeric,
         "  \t--domain\t  \t" \
-        "Set the domain (0-255) to replay on. " \
+        "Set the domain (0-232) to replay on. " \
         "[Default = 0]."
     },
 
@@ -263,8 +264,34 @@ ProcessReturnCode parse_arguments(
                     break;
 
                 case optionIndex::DOMAIN:
-                    commandline_args.domain.set_value(std::stoi(opt.arg));
-                    break;
+                {
+                    const auto max_domain_id = static_cast<long>(ddspipe::core::types::DomainId::MAX_DOMAIN_ID);
+                    long domain_value = 0;
+
+                    try
+                    {
+                        domain_value = std::stol(opt.arg);
+                    }
+                    catch (const std::exception&)
+                    {
+                        EPROSIMA_LOG_ERROR(
+                            DDSREPLAYER_ARGS,
+                            "Domain ID must be between 0 and " << max_domain_id << ".");
+                        return ProcessReturnCode::incorrect_argument;
+                    }
+
+                    if (domain_value < 0 || domain_value > max_domain_id)
+                    {
+                        EPROSIMA_LOG_ERROR(
+                            DDSREPLAYER_ARGS,
+                            "Domain ID must be between 0 and " << max_domain_id << ".");
+                        return ProcessReturnCode::incorrect_argument;
+                    }
+
+                    commandline_args.domain.set_value(
+                        static_cast<ddspipe::core::types::DomainIdType>(domain_value));
+                }
+                break;
 
                 case optionIndex::ACTIVATE_DEBUG:
                     commandline_args.log_filter[utils::VerbosityKind::Error].set_value("");

--- a/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
@@ -112,6 +112,17 @@ const option::Descriptor usage[] = {
 
     },
 
+    {
+        optionIndex::DOMAIN,
+        0,
+        "",
+        "domain",
+        Arg::Numeric,
+        "  \t--domain\t  \t" \
+        "Set the domain (0-255) to replay on. " \
+        "[Default = 0]."
+    },
+
     ////////////////////
     // Debug options
     {
@@ -249,6 +260,10 @@ ProcessReturnCode parse_arguments(
 
                 case optionIndex::RELOAD_TIME:
                     commandline_args.reload_time = std::stol(opt.arg) * 1000; // pass to milliseconds
+                    break;
+
+                case optionIndex::DOMAIN:
+                    commandline_args.domain.set_value(std::stoi(opt.arg));
                     break;
 
                 case optionIndex::ACTIVATE_DEBUG:

--- a/ddsreplayer/src/cpp/user_interface/arguments_configuration.hpp
+++ b/ddsreplayer/src/cpp/user_interface/arguments_configuration.hpp
@@ -100,6 +100,7 @@ enum optionIndex
     VERSION,
     LOG_FILTER,
     LOG_VERBOSITY,
+    DOMAIN,
 };
 
 /**

--- a/docs/rst/recording/usage/usage.rst
+++ b/docs/rst/recording/usage/usage.rst
@@ -140,7 +140,7 @@ The |ddsrecorder| application supports several input arguments:
     *   - Domain
         - Set the domain to record on
         - ``--domain``
-        - Unsigned Integer [0-255]
+        - Unsigned Integer [0-232]
         - 0
 
     *   - Debug

--- a/docs/rst/recording/usage/usage.rst
+++ b/docs/rst/recording/usage/usage.rst
@@ -137,6 +137,12 @@ The |ddsrecorder| application supports several input arguments:
         - Unsigned Integer
         - ``0``
 
+    *   - Domain
+        - Set the domain to record on
+        - ``--domain``
+        - Unsigned Integer [0-255]
+        - 0
+
     *   - Debug
         - Enables the |ddsrecorder| |br|
           logs so the execution can be |br|

--- a/docs/rst/replaying/usage/usage.rst
+++ b/docs/rst/replaying/usage/usage.rst
@@ -130,6 +130,12 @@ The |ddsreplayer| application supports several input arguments:
         - Unsigned Integer
         - ``0``
 
+    *   - Domain
+        - Set the domain to replay on
+        - ``--domain``
+        - Unsigned Integer [0-255]
+        - 0
+
     *   - Debug
         - Enables the |ddsreplayer| |br|
           logs so the execution can be |br|

--- a/docs/rst/replaying/usage/usage.rst
+++ b/docs/rst/replaying/usage/usage.rst
@@ -133,7 +133,7 @@ The |ddsreplayer| application supports several input arguments:
     *   - Domain
         - Set the domain to replay on
         - ``--domain``
-        - Unsigned Integer [0-255]
+        - Unsigned Integer [0-232]
         - 0
 
     *   - Debug


### PR DESCRIPTION
## Description
This PR adds a new `--domain` command-line option for both `ddsrecorder` and `ddsreplayer`, allowing users to select the DDS domain without editing YAML files.

### Updated docs:
  - `docs/rst/recording/usage/usage.rst`
  - `docs/rst/replaying/usage/usage.rst`
