### PR TITLE
[#24302] Fix replay behavior to avoid runtime aborts and keyed-topic issues

### DIFF
--- a/ddsrecorder_participants/include/ddsrecorder_participants/common/instance_handle_utils.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/common/instance_handle_utils.hpp
@@ -1,0 +1,56 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include <fastdds/rtps/common/InstanceHandle.hpp>
+#include <fastdds/utils/md5.hpp>
+
+namespace eprosima {
+namespace ddsrecorder {
+namespace participants {
+namespace detail {
+
+inline fastdds::rtps::InstanceHandle_t compute_instance_handle_from_seed(
+        const std::string& seed)
+{
+    fastdds::rtps::InstanceHandle_t handle;
+    eprosima::fastdds::MD5 md5;
+
+    md5.init();
+    md5.update(
+        reinterpret_cast<const unsigned char*>(seed.data()),
+        static_cast<unsigned int>(seed.size()));
+    md5.finalize();
+
+    for (std::size_t i = 0; i < 16; ++i)
+    {
+        handle.value[i] = md5.digest[i];
+    }
+
+    // Keep Fast DDS from considering this instance handle undefined
+    if (!handle.isDefined())
+    {
+        handle.value[0] = 1;
+    }
+
+    return handle;
+}
+
+} // namespace detail
+} // namespace participants
+} // namespace ddsrecorder
+} // namespace eprosima

--- a/ddsrecorder_participants/include/ddsrecorder_participants/replayer/XmlReplayerParticipant.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/replayer/XmlReplayerParticipant.hpp
@@ -41,13 +41,16 @@ public:
      * @param discovery_database Reference to a \c DiscoveryDatabase instance.
      * @param replay_types Boolean flag in the Replayer configuration that determines whether
      *        previously recorded types are transmitted.
+     * @param forced_domain Domain configured by DDS Replayer (YAML / CLI). This is reapplied so it keeps
+     *        precedence over XML profile domain defaults.
      */
     DDSRECORDER_PARTICIPANTS_DllAPI
     XmlReplayerParticipant(
             const std::shared_ptr<ddspipe::participants::XmlParticipantConfiguration>& participant_configuration,
             const std::shared_ptr<ddspipe::core::PayloadPool>& payload_pool,
             const std::shared_ptr<ddspipe::core::DiscoveryDatabase>& discovery_database,
-            const bool& replay_types);
+            const bool& replay_types,
+            ddspipe::core::types::DomainId forced_domain);
 
     /**
      * Override create_reader_() IParticipant method.

--- a/ddsrecorder_participants/src/cpp/replayer/McapReaderParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/McapReaderParticipant.cpp
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <exception>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -37,6 +38,7 @@
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 
+#include <ddsrecorder_participants/common/instance_handle_utils.hpp>
 #include <ddsrecorder_participants/common/serialize/Serializer.hpp>
 #include <ddsrecorder_participants/common/time_utils.hpp>
 #include <ddsrecorder_participants/common/types/dynamic_types_collection/DynamicTypesCollection.hpp>
@@ -382,6 +384,15 @@ void McapReaderParticipant::process_messages()
 
         // Create RTPS data
         auto data = create_payload_(it.message.data, it.message.dataSize);
+
+        // Rebuild a deterministic instance handle for keyed topics
+        if (topic.topic_qos.keyed)
+        {
+            std::ostringstream key_seed;
+            key_seed << it.channel->topic << '|' << it.schema->name << '|' << writer_guid << '|'
+                     << it.message.sequence;
+            data->instanceHandle = detail::compute_instance_handle_from_seed(key_seed.str());
+        }
 
         // Set source timestamp
         // NOTE: this is important for QoS such as LifespanQosPolicy

--- a/ddsrecorder_participants/src/cpp/replayer/McapReaderParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/McapReaderParticipant.cpp
@@ -404,7 +404,7 @@ void McapReaderParticipant::process_messages()
             else
             {
                 partition_name = it_partition->second;
-                if (partition_name.size() > 0)
+                if (!partition_name.empty())
                 {
                     int i = 0, partition_name_n = partition_name.size();
                     std::string tmp = "";
@@ -424,13 +424,18 @@ void McapReaderParticipant::process_messages()
                     }
                     // add the last partition in the set of partitions.
                     // e.g.: "A|B" adds the "B" partition
-                    if (tmp != "")
+                    if (!tmp.empty() || partition_name[partition_name_n - 1] == '|')
                     {
                         data->writer_qos.partitions.push_back(tmp.c_str());
                     }
 
                 }
-                data->writer_qos.partitions.push_back(partition_name.c_str());
+                // Empty partition set ("") must still be represented with one empty partition.
+                else
+                {
+                    data->writer_qos.partitions.push_back("");
+                }
+
                 partitions_qos_dict_[writer_guid] = data->writer_qos.partitions;
             }
         }

--- a/ddsrecorder_participants/src/cpp/replayer/McapReaderParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/McapReaderParticipant.cpp
@@ -17,6 +17,8 @@
  */
 
 #include <chrono>
+#include <exception>
+#include <stdexcept>
 #include <string>
 
 #include <mcap/errors.hpp>
@@ -145,26 +147,49 @@ void McapReaderParticipant::process_summary(
     for (const auto& [_, channel]: channels)
     {
         const auto topic_name = channel->topic;
-        const auto type_name = schemas.at(channel->schemaId)->name;
+        const auto schema_it = schemas.find(channel->schemaId);
+        if (schema_it == schemas.end() || !schema_it->second)
+        {
+            EPROSIMA_LOG_WARNING(DDSREPLAYER_MCAP_READER_PARTICIPANT,
+                    "Skipping topic " << topic_name
+                                      << ": schema with id " << channel->schemaId << " not found.");
+            continue;
+        }
+        const auto type_name = schema_it->second->name;
 
-        const bool is_topic_ros2_type = channel->metadata[ROS2_TYPES] == "true";
+        const auto ros2_types_it = channel->metadata.find(ROS2_TYPES);
+        const bool is_topic_ros2_type =
+                ros2_types_it != channel->metadata.end() && ros2_types_it->second == "true";
         const auto topic = utils::Heritable<ddspipe::core::types::DdsTopic>::make_heritable(
             create_topic_(topic_name, type_name, is_topic_ros2_type));
 
         const auto topic_id = std::make_pair(topic_name, type_name);
 
         // Apply the QoS stored in the MCAP file as if they were the discovered QoS.
-        const auto topic_qos_str = channel->metadata[QOS_SERIALIZATION_QOS];
-        ddspipe::core::types::TopicQoS topic_qos;
-        Serializer::deserialize<ddspipe::core::types::TopicQoS>(topic_qos_str, topic_qos);
-
-        topic->topic_qos.set_qos(topic_qos, utils::FuzzyLevelValues::fuzzy_level_fuzzy);
+        const auto topic_qos_it = channel->metadata.find(QOS_SERIALIZATION_QOS);
+        if (topic_qos_it != channel->metadata.end())
+        {
+            ddspipe::core::types::TopicQoS topic_qos;
+            Serializer::deserialize<ddspipe::core::types::TopicQoS>(topic_qos_it->second, topic_qos);
+            topic->topic_qos.set_qos(topic_qos, utils::FuzzyLevelValues::fuzzy_level_fuzzy);
+        }
+        else
+        {
+            EPROSIMA_LOG_WARNING(DDSREPLAYER_MCAP_READER_PARTICIPANT,
+                    "Topic " << topic_name
+                             << " has no serialized QoS metadata. Using default QoS.");
+        }
 
         std::string writer = "";
         std::string writer_partition = "";
         bool pass_partition_filter;
 
-        std::string channel_partitions = channel->metadata[PARTITIONS];
+        std::string channel_partitions;
+        const auto partitions_it = channel->metadata.find(PARTITIONS);
+        if (partitions_it != channel->metadata.end())
+        {
+            channel_partitions = partitions_it->second;
+        }
 
         // adds the partitions of the topic using the stored channel
         // metadata[partitions] = <writer_1>:<partition_1>;...;<writer_n>:<partition_n>
@@ -270,9 +295,10 @@ void McapReaderParticipant::process_summary(
     // Get the dynamic types from the attachment
     const auto attachments = mcap_reader_.attachments();
 
-    if (attachments.find(DYNAMIC_TYPES_ATTACHMENT_NAME) != attachments.end())
+    const auto dynamic_types_attachment_it = attachments.find(DYNAMIC_TYPES_ATTACHMENT_NAME);
+    if (dynamic_types_attachment_it != attachments.end())
     {
-        const auto dynamic_types_attachment = attachments.at(DYNAMIC_TYPES_ATTACHMENT_NAME);
+        const auto& dynamic_types_attachment = dynamic_types_attachment_it->second;
 
         const std::string dynamic_types_str(
             reinterpret_cast<const char*>(dynamic_types_attachment.data), dynamic_types_attachment.dataSize);
@@ -309,10 +335,26 @@ void McapReaderParticipant::process_messages()
         // Create topic on which this message should be published
 
         const auto topic_id = std::make_pair(it.channel->topic, it.schema->name);
-        const auto topic = topics_[topic_id];
+        const auto topic_it = topics_.find(topic_id);
+        if (topic_it == topics_.end())
+        {
+            EPROSIMA_LOG_WARNING(DDSREPLAYER_MCAP_READER_PARTICIPANT,
+                    "Skipping message for unknown topic "
+                    << it.channel->topic << " with type " << it.schema->name << ".");
+            continue;
+        }
+        const auto& topic = topic_it->second;
         const std::string seq_num_str = std::to_string(it.message.sequence);
-        const std::string source_guid_indx = source_guid_by_sequence_[seq_num_str];
-        const std::string writer_guid = sequence_by_source_guid_index_[source_guid_indx];
+        std::string writer_guid = "";
+        const auto source_guid_it = source_guid_by_sequence_.find(seq_num_str);
+        if (source_guid_it != source_guid_by_sequence_.end())
+        {
+            const auto writer_guid_it = sequence_by_source_guid_index_.find(source_guid_it->second);
+            if (writer_guid_it != sequence_by_source_guid_index_.end())
+            {
+                writer_guid = writer_guid_it->second;
+            }
+        }
 
         if (filtered_writersguid_list_.find(writer_guid) != filtered_writersguid_list_.end())
         {
@@ -399,8 +441,17 @@ void McapReaderParticipant::process_messages()
         EPROSIMA_LOG_INFO(DDSREPLAYER_MCAP_READER_PARTICIPANT,
                 "Replaying message in topic " << topic << ".");
 
-        // Insert new data in internal reader queue
-        readers_it->second->simulate_data_reception(std::move(data));
+        // Insert new data in internal reader queue, with a try catch
+        try
+        {
+            readers_it->second->simulate_data_reception(std::move(data));
+        }
+        catch (const std::exception& e)
+        {
+            EPROSIMA_LOG_ERROR(DDSREPLAYER_MCAP_READER_PARTICIPANT,
+                    "Failed to replay message in topic " << topic
+                                                         << ": " << e.what() << ". Skipping...");
+        }
     }
 
     close_file_();
@@ -439,10 +490,22 @@ void McapReaderParticipant::read_mcap_summary_()
     const auto metadata = mcap_reader_.metadata();
     std::string recording_version;
 
-    if (metadata.find(VERSION_METADATA_NAME) != metadata.end())
+    // Version metadata, not guaranteed in all files, if absent replay the file
+    // without failures, just log a warning message
+    const auto version_metadata_it = metadata.find(VERSION_METADATA_NAME);
+    if (version_metadata_it != metadata.end())
     {
-        const auto version_metadata = metadata.at(VERSION_METADATA_NAME).metadata;
-        recording_version = version_metadata.at(VERSION_METADATA_RELEASE);
+        const auto& version_metadata = version_metadata_it->second.metadata;
+        const auto release_it = version_metadata.find(VERSION_METADATA_RELEASE);
+        if (release_it != version_metadata.end())
+        {
+            recording_version = release_it->second;
+        }
+        else
+        {
+            EPROSIMA_LOG_WARNING(DDSREPLAYER_MCAP_READER_PARTICIPANT,
+                    "MCAP metadata does not include recording release information.");
+        }
     }
 
     if (recording_version != DDSRECORDER_PARTICIPANTS_VERSION_STRING)
@@ -454,10 +517,27 @@ void McapReaderParticipant::read_mcap_summary_()
                 << "), incompatibilities might arise...");
     }
 
-    if (metadata.find(VERSION_METADATA_MESSAGE_NAME) != metadata.end())
+    const auto sequence_metadata_it = metadata.find(VERSION_METADATA_MESSAGE_NAME);
+    if (sequence_metadata_it != metadata.end())
     {
-        source_guid_by_sequence_ = metadata.at(VERSION_METADATA_MESSAGE_NAME).metadata;
-        sequence_by_source_guid_index_ = metadata.at(VERSION_METADATA_MESSAGE_INDEX_NAME).metadata;
+        source_guid_by_sequence_ = sequence_metadata_it->second.metadata;
+
+        const auto source_guid_index_metadata_it = metadata.find(VERSION_METADATA_MESSAGE_INDEX_NAME);
+        if (source_guid_index_metadata_it != metadata.end())
+        {
+            sequence_by_source_guid_index_ = source_guid_index_metadata_it->second.metadata;
+        }
+        else
+        {
+            EPROSIMA_LOG_WARNING(DDSREPLAYER_MCAP_READER_PARTICIPANT,
+                    "MCAP metadata does not include source-guid index map.");
+            sequence_by_source_guid_index_.clear();
+        }
+    }
+    else
+    {
+        source_guid_by_sequence_.clear();
+        sequence_by_source_guid_index_.clear();
     }
 }
 

--- a/ddsrecorder_participants/src/cpp/replayer/SqlReaderParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/SqlReaderParticipant.cpp
@@ -459,7 +459,7 @@ void SqlReaderParticipant::process_messages()
                 else
                 {
                     partition_name = it->second;
-                    if (partition_name.size() > 0)
+                    if (!partition_name.empty())
                     {
                         int i = 0, partition_name_n = partition_name.size();
                         std::string tmp = "";
@@ -479,15 +479,18 @@ void SqlReaderParticipant::process_messages()
                         }
                         // add the last partition in the set of partitions.
                         // e.g.: "A|B" adds the "B" partition
-                        if (tmp != "")
+                        if (!tmp.empty() || partition_name[partition_name_n - 1] == '|')
                         {
                             data->writer_qos.partitions.push_back(tmp.c_str());
                         }
 
                     }
+                    // Empty partition ("")
+                    else
+                    {
+                        data->writer_qos.partitions.push_back("");
+                    }
 
-                    // adds the partitions in the writer guid PartitionsQos
-                    data->writer_qos.partitions.push_back(partition_name.c_str());
                     partitions_qos_dict_[writer_guid] = data->writer_qos.partitions;
                 }
             }

--- a/ddsrecorder_participants/src/cpp/replayer/SqlReaderParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/SqlReaderParticipant.cpp
@@ -27,7 +27,6 @@
 #include <sqlite/sqlite3.h>
 
 #include <fastdds/dds/core/Time_t.hpp>
-#include <fastdds/utils/md5.hpp>
 
 #include <cpp_utils/exception/InconsistencyException.hpp>
 #include <cpp_utils/Log.hpp>
@@ -38,6 +37,7 @@
 
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 
+#include <ddsrecorder_participants/common/instance_handle_utils.hpp>
 #include <ddsrecorder_participants/common/serialize/Serializer.hpp>
 #include <ddsrecorder_participants/common/time_utils.hpp>
 #include <ddsrecorder_participants/constants.hpp>
@@ -47,32 +47,6 @@
 namespace eprosima {
 namespace ddsrecorder {
 namespace participants {
-
-static fastdds::rtps::InstanceHandle_t compute_instance_handle_from_seed_(
-        const std::string& seed)
-{
-    fastdds::rtps::InstanceHandle_t handle;
-    eprosima::fastdds::MD5 md5;
-
-    md5.init();
-    md5.update(
-        reinterpret_cast<const unsigned char*>(seed.data()),
-        static_cast<unsigned int>(seed.size()));
-    md5.finalize();
-
-    for (std::size_t i = 0; i < 16; ++i)
-    {
-        handle.value[i] = md5.digest[i];
-    }
-
-    // Keep Fast DDS from considering this instance handle undefined
-    if (!handle.isDefined())
-    {
-        handle.value[0] = 1;
-    }
-
-    return handle;
-}
 
 SqlReaderParticipant::SqlReaderParticipant(
         const std::shared_ptr<BaseReaderParticipantConfiguration>& configuration,
@@ -435,7 +409,7 @@ void SqlReaderParticipant::process_messages()
                     key_seed << writer_guid << '|' << sequence_number;
                 }
 
-                data->instanceHandle = compute_instance_handle_from_seed_(key_seed.str());
+                data->instanceHandle = detail::compute_instance_handle_from_seed(key_seed.str());
             }
 
             // Set source timestamp

--- a/ddsrecorder_participants/src/cpp/replayer/SqlReaderParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/SqlReaderParticipant.cpp
@@ -17,13 +17,17 @@
  */
 
 #include <cstring>
+#include <exception>
 #include <map>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
 #include <sqlite/sqlite3.h>
 
 #include <fastdds/dds/core/Time_t.hpp>
+#include <fastdds/utils/md5.hpp>
 
 #include <cpp_utils/exception/InconsistencyException.hpp>
 #include <cpp_utils/Log.hpp>
@@ -43,6 +47,32 @@
 namespace eprosima {
 namespace ddsrecorder {
 namespace participants {
+
+static fastdds::rtps::InstanceHandle_t compute_instance_handle_from_seed_(
+        const std::string& seed)
+{
+    fastdds::rtps::InstanceHandle_t handle;
+    eprosima::fastdds::MD5 md5;
+
+    md5.init();
+    md5.update(
+        reinterpret_cast<const unsigned char*>(seed.data()),
+        static_cast<unsigned int>(seed.size()));
+    md5.finalize();
+
+    for (std::size_t i = 0; i < 16; ++i)
+    {
+        handle.value[i] = md5.digest[i];
+    }
+
+    // Keep Fast DDS from considering this instance handle undefined
+    if (!handle.isDefined())
+    {
+        handle.value[0] = 1;
+    }
+
+    return handle;
+}
 
 SqlReaderParticipant::SqlReaderParticipant(
         const std::shared_ptr<BaseReaderParticipantConfiguration>& configuration,
@@ -312,17 +342,24 @@ void SqlReaderParticipant::process_messages()
         configuration_->end_time.get_reference() :
         utils::the_end_of_time());
 
+    bool first_message_timestamp_set = false;
+    utils::Timestamp first_message_timestamp{};
+
     exec_sql_statement_(
-        "SELECT log_time, topic, type, data_cdr, data_cdr_size, writer_guid FROM Messages "
+        "SELECT log_time, topic, type, data_cdr, data_cdr_size, writer_guid, key, sequence_number FROM Messages "
         "WHERE log_time >= ? AND log_time <= ? AND data_cdr_size > 0 "
-        "ORDER BY log_time;",
+        "ORDER BY log_time, writer_guid, sequence_number;",
         {begin_time, end_time},
         [&](sqlite3_stmt* stmt)
         {
             const auto log_time = to_std_timestamp(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0)));
 
-            // Store the timestamp of the first recorded message
-            static utils::Timestamp first_message_timestamp = log_time;
+            // Store the timestamp of the first recorded message in this replay execution.
+            if (!first_message_timestamp_set)
+            {
+                first_message_timestamp = log_time;
+                first_message_timestamp_set = true;
+            }
 
             // Create a DdsTopic to publish the message
             ddspipe::core::types::DdsTopic topic;
@@ -330,6 +367,9 @@ void SqlReaderParticipant::process_messages()
             const std::string type_name = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2));
 
             const std::string writer_guid = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5));
+            const auto* key_col = sqlite3_column_text(stmt, 6);
+            const std::string key = key_col ? reinterpret_cast<const char*>(key_col) : "";
+            const auto sequence_number = sqlite3_column_int64(stmt, 7);
 
             const auto topic_id = std::make_pair(topic_name, type_name);
 
@@ -379,6 +419,24 @@ void SqlReaderParticipant::process_messages()
             const auto raw_data = sqlite3_column_blob(stmt, 3);
             const auto raw_data_size = sqlite3_column_int(stmt, 4);
             auto data = create_payload_(raw_data, raw_data_size);
+
+            // Rebuild a deterministic instance handle for keyed topics from recorded SQL key data
+            // This avoids dropping keyed samples when dynamic type dependencies are not resolvable
+            if (topic.topic_qos.keyed)
+            {
+                std::ostringstream key_seed;
+                key_seed << topic_name << '|' << type_name << '|';
+                if (!key.empty())
+                {
+                    key_seed << key;
+                }
+                else
+                {
+                    key_seed << writer_guid << '|' << sequence_number;
+                }
+
+                data->instanceHandle = compute_instance_handle_from_seed_(key_seed.str());
+            }
 
             // Set source timestamp
             // NOTE: this is important for QoS such as LifespanQosPolicy
@@ -440,8 +498,17 @@ void SqlReaderParticipant::process_messages()
             EPROSIMA_LOG_INFO(DDSREPLAYER_SQL_READER_PARTICIPANT,
             "Replaying message in topic " << topic << ".");
 
-            // Insert new data in internal reader queue
-            readers_[topic]->simulate_data_reception(std::move(data));
+            // Insert new data in internal reader queue, with a try catch
+            try
+            {
+                readers_[topic]->simulate_data_reception(std::move(data));
+            }
+            catch (const std::exception& e)
+            {
+                EPROSIMA_LOG_ERROR(
+                    DDSREPLAYER_SQL_READER_PARTICIPANT,
+                    "Failed to replay message in topic " << topic << ": " << e.what() << ". Skipping...");
+            }
         });
 
     close_file_();

--- a/ddsrecorder_participants/src/cpp/replayer/XmlReplayerParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/XmlReplayerParticipant.cpp
@@ -29,13 +29,17 @@ XmlReplayerParticipant::XmlReplayerParticipant(
         const std::shared_ptr<XmlParticipantConfiguration>& participant_configuration,
         const std::shared_ptr<PayloadPool>& payload_pool,
         const std::shared_ptr<DiscoveryDatabase>& discovery_database,
-        const bool& replay_types)
+        const bool& replay_types,
+        ddspipe::core::types::DomainId forced_domain)
     : XmlParticipant(
         participant_configuration,
         payload_pool,
         discovery_database)
     , replay_types_(replay_types)
 {
+    // XmlParticipant may overwrite configuration domain from profile metadata
+    // Reapply the configured domain so CLI/YAML precedence is respected
+    configuration_->domain = forced_domain;
 }
 
 std::shared_ptr<IReader> XmlReplayerParticipant::create_reader(

--- a/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
+++ b/ddsreplayer/src/cpp/tool/DdsReplayer.cpp
@@ -107,7 +107,8 @@ DdsReplayer::DdsReplayer(
             configuration.replayer_configuration,
             payload_pool_,
             discovery_database,
-            configuration.replay_types);
+            configuration.replay_types,
+            configuration.replayer_configuration->domain);
 
         std::dynamic_pointer_cast<participants::XmlReplayerParticipant>(replayer_participant)->init();
     }

--- a/docs/rst/developer_manual/installation/sources/windows.rst
+++ b/docs/rst/developer_manual/installation/sources/windows.rst
@@ -258,7 +258,7 @@ Colcon installation (recommended)
         cd <path\to\user\workspace>\DDS-Record-Replay
         mkdir src
         wget https://raw.githubusercontent.com/eProsima/DDS-Record-Replay/main/ddsrecordreplay.repos ddsrecordreplay.repos
-        vcs import src < ddsrecordreplay.repos
+        vcs import src --input ddsrecordreplay.repos
 
     .. note::
 
@@ -304,7 +304,7 @@ Local installation
         mkdir <path\to\user\workspace>\DDS-Record-Replay\build
         cd <path\to\user\workspace>\DDS-Record-Replay
         wget https://raw.githubusercontent.com/eProsima/DDS-Record-Replay/main/ddsrecordreplay.repos ddsrecordreplay.repos
-        vcs import src < ddsrecordreplay.repos
+        vcs import src --input ddsrecordreplay.repos
 
 #.  Compile all dependencies using CMake_.
 


### PR DESCRIPTION
## Description
This PR hardens replay behavior in SqlReaderParticipant and McapReaderParticipant to avoid runtime aborts and improve keyed-topic replay reliability.

## Changes
- Fixed SQL replay ordering and timing handling to avoid missing/shifted first samples.
- Improved keyed-topic replay in SQL path by restoring deterministic instance-handle behavior from recorded key data (with fallback seed path).
- Changed metadata checks to not fail if the version is not present in the file
- Changed maps implementation to use find() instead of [] or .at()
## Changes after DDS-Pipe (TopicDataType.cpp removed code)
- Added `instance_handle_utils.hpp` with `compute_instance_handle_from_seed(...)`
- Updated:
  - `SqlReaderParticipant.cpp`
  - `McapReaderParticipant.cpp`

E.G.:
```cpp
// BEFORE
const auto topic = topics_[topic_id];
// AFTER
const auto topic_it = topics_.find(topic_id);
if (topic_it == topics_.end()) { ... }
const auto& topic = topic_it->second;
```
