### PR TITLE
[#24332] Fix `ddsrecorder_controller` compilation in both OS

### DIFF
--- a/controller/controller_tool/ddstypes/DdsRecorderCommand/CMakeLists.txt
+++ b/controller/controller_tool/ddstypes/DdsRecorderCommand/CMakeLists.txt
@@ -62,6 +62,33 @@ set(PYTHON_INCLUDE_PATH ${Python3_INCLUDE_DIRS})
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 set(PYTHON_LIBRARIES ${Python3_LIBRARIES})
 
+if (WIN32)
+    # Detect stale CMake cache cases where interpreter and development library
+    # point to different Python ABIs (e.g. python312.lib, python311.lib, cp312 ...)
+    set(_python3_library_to_check "${Python3_LIBRARY_RELEASE}")
+    if (NOT _python3_library_to_check)
+        list(GET Python3_LIBRARIES 0 _python3_library_to_check)
+    endif()
+
+    if (_python3_library_to_check)
+        get_filename_component(_python3_library_name "${_python3_library_to_check}" NAME)
+        string(REGEX MATCH "python([0-9]+)(_d)?\\.lib" _python3_library_match "${_python3_library_name}")
+        if (_python3_library_match)
+            set(_python3_abi_expected "${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
+            set(_python3_abi_from_library "${CMAKE_MATCH_1}")
+            if (NOT _python3_abi_expected STREQUAL _python3_abi_from_library)
+                message(FATAL_ERROR
+                    "Python interpreter/development mismatch detected.\n"
+                    "Interpreter: ${Python3_EXECUTABLE} (cp${_python3_abi_expected})\n"
+                    "Development library: ${_python3_library_to_check} (cp${_python3_abi_from_library})\n"
+                    "Clean the build directory (or use --cmake-clean-cache) and reconfigure with "
+                    "-DPython3_EXECUTABLE=<path-to-python.exe>."
+                )
+            endif()
+        endif()
+    endif()
+endif()
+
 include_directories(${PYTHON_INCLUDE_PATH})
 
 set(${PROJECT_NAME}_MODULE

--- a/controller/controller_tool/ddstypes/DdsRecorderStatus/CMakeLists.txt
+++ b/controller/controller_tool/ddstypes/DdsRecorderStatus/CMakeLists.txt
@@ -57,6 +57,33 @@ set(PYTHON_INCLUDE_PATH ${Python3_INCLUDE_DIRS})
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 set(PYTHON_LIBRARIES ${Python3_LIBRARIES})
 
+if (WIN32)
+    # Detect stale CMake cache cases where interpreter and development library
+    # point to different Python ABIs (e.g. python312.lib, python311.lib, cp312 ...)
+    set(_python3_library_to_check "${Python3_LIBRARY_RELEASE}")
+    if (NOT _python3_library_to_check)
+        list(GET Python3_LIBRARIES 0 _python3_library_to_check)
+    endif()
+
+    if (_python3_library_to_check)
+        get_filename_component(_python3_library_name "${_python3_library_to_check}" NAME)
+        string(REGEX MATCH "python([0-9]+)(_d)?\\.lib" _python3_library_match "${_python3_library_name}")
+        if (_python3_library_match)
+            set(_python3_abi_expected "${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
+            set(_python3_abi_from_library "${CMAKE_MATCH_1}")
+            if (NOT _python3_abi_expected STREQUAL _python3_abi_from_library)
+                message(FATAL_ERROR
+                    "Python interpreter/development mismatch detected.\n"
+                    "Interpreter: ${Python3_EXECUTABLE} (cp${_python3_abi_expected})\n"
+                    "Development library: ${_python3_library_to_check} (cp${_python3_abi_from_library})\n"
+                    "Clean the build directory (or use --cmake-clean-cache) and reconfigure with "
+                    "-DPython3_EXECUTABLE=<path-to-python.exe>."
+                )
+            endif()
+        endif()
+    endif()
+endif()
+
 include_directories(${PYTHON_INCLUDE_PATH})
 
 set(${PROJECT_NAME}_MODULE

--- a/controller/controller_tool/tool/CMakeLists.txt
+++ b/controller/controller_tool/tool/CMakeLists.txt
@@ -30,9 +30,15 @@ install(
 if (MSVC)
 
     # Windows
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    configure_file(
+        executable/ddsrecorder_controller.bat.in
+        ${CMAKE_CURRENT_BINARY_DIR}/ddsrecorder_controller.bat
+        @ONLY
+    )
     install(
         FILES
-            executable/ddsrecorder_controller.bat
+            ${CMAKE_CURRENT_BINARY_DIR}/ddsrecorder_controller.bat
         DESTINATION
             ${BIN_INSTALL_DIR}
     )

--- a/controller/controller_tool/tool/executable/ddsrecorder_controller
+++ b/controller/controller_tool/tool/executable/ddsrecorder_controller
@@ -1,2 +1,21 @@
-dir="`dirname \"$0\"`"
-python3 "$dir/../src/ddsrecorder_controller.py" ${@}
+dir="$(dirname "$0")"
+
+# Prioritize the Qt runtime distributed with PyQt6 to avoid ABI mismatches with
+# Qt libraries that may be injected from the environment (e.g. /opt/qt/*).
+pyqt6_lib="$(python3 - <<'PY'
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.find_spec("PyQt6")
+if spec and spec.origin:
+    qt6_lib = Path(spec.origin).resolve().parent / "Qt6" / "lib"
+    if qt6_lib.is_dir():
+        print(qt6_lib)
+PY
+)"
+
+if [ -n "$pyqt6_lib" ]; then
+    export LD_LIBRARY_PATH="$pyqt6_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+python3 "$dir/../src/ddsrecorder_controller.py" "$@"

--- a/controller/controller_tool/tool/executable/ddsrecorder_controller.bat.in
+++ b/controller/controller_tool/tool/executable/ddsrecorder_controller.bat.in
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+set "dir=%~dp0"
+set "script=%dir%\..\src\ddsrecorder_controller.py"
+set "configured_python=@Python3_EXECUTABLE@"
+
+if not exist "%script%" (
+    echo ddsrecorder_controller.py not found at "%script%".
+    exit /B 66
+)
+
+if exist "%configured_python%" (
+    "%configured_python%" "%script%" %*
+    exit /B %ERRORLEVEL%
+)
+
+:: Fallback to launcher if configured interpreter is unavailable.
+py --list > NUL 2>&1
+if %ERRORLEVEL%==0 (
+    py "%script%" %*
+    exit /B %ERRORLEVEL%
+)
+
+echo python interpreter not found. Please, make sure its location is in the PATH environment variable.
+exit /B 65

--- a/ddsrecorder_participants/src/cpp/replayer/SqlReaderParticipant.cpp
+++ b/ddsrecorder_participants/src/cpp/replayer/SqlReaderParticipant.cpp
@@ -27,6 +27,7 @@
 #include <sqlite/sqlite3.h>
 
 #include <fastdds/dds/core/Time_t.hpp>
+#include <fastdds/utils/md5.hpp>
 
 #include <cpp_utils/exception/InconsistencyException.hpp>
 #include <cpp_utils/Log.hpp>
@@ -47,6 +48,32 @@
 namespace eprosima {
 namespace ddsrecorder {
 namespace participants {
+
+static fastdds::rtps::InstanceHandle_t compute_instance_handle_from_seed_(
+        const std::string& seed)
+{
+    fastdds::rtps::InstanceHandle_t handle;
+    eprosima::fastdds::MD5 md5;
+
+    md5.init();
+    md5.update(
+        reinterpret_cast<const unsigned char*>(seed.data()),
+        static_cast<unsigned int>(seed.size()));
+    md5.finalize();
+
+    for (std::size_t i = 0; i < 16; ++i)
+    {
+        handle.value[i] = md5.digest[i];
+    }
+
+    // Keep Fast DDS from considering this instance handle undefined
+    if (!handle.isDefined())
+    {
+        handle.value[0] = 1;
+    }
+
+    return handle;
+}
 
 SqlReaderParticipant::SqlReaderParticipant(
         const std::shared_ptr<BaseReaderParticipantConfiguration>& configuration,
@@ -408,6 +435,7 @@ void SqlReaderParticipant::process_messages()
                 {
                     key_seed << writer_guid << '|' << sequence_number;
                 }
+
 
                 data->instanceHandle = detail::compute_instance_handle_from_seed(key_seed.str());
             }

--- a/docs/rst/recording/remote_control/remote_control.rst
+++ b/docs/rst/recording/remote_control/remote_control.rst
@@ -170,7 +170,7 @@ Thus the user can control a |ddsrecorder| instance using this application withou
 
 .. note::
 
-    If installing |eddsrecord| from sources, compilation flag ``-DBUILD_DDSRECORDER_CONTROLLER=ON`` is required to build this application.
+    If installing |eddsrecord| from sources, compilation flag ``-DBUILD_DDSRECORDER_CONTROLLER=ON`` is required to build this application. And a python environment with ``PyQt6`` installed.
 
 Its interface is quite simple and intuitive.
 Once the application is launched, a layout as the following one should be visible:


### PR DESCRIPTION
## Description
This PR solves `ddsrecorder_controller` compilation across platforms by fixing runtime/toolchain mismatches that caused startup or build failures.

- Linux: `ddsrecorder_controller` could load mixed Qt versions from environment paths (e.g. `/opt/qt/...`) and fail with Qt private API symbol errors.
- Windows: stale CMake cache could mix Python interpreter ABI and development library ABI (e.g. cp312 interpreter with python311.lib), causing hard-to-debug build/runtime issues.
- Windows launcher: execution could use an unintended Python interpreter.

Documentation for windows
- Windows docs: `vcs import` command used shell redirection syntax that is less robust in this context.

## Changes
- POSIX launcher (`ddsrecorder_controller`):
  - Detect PyQt6 location at runtime.
  - Prepend PyQt6 `Qt6/lib` to `LD_LIBRARY_PATH`.
- Windows launcher:
  - Generate `.bat` from `ddsrecorder_controller.bat.in` using `Python3_EXECUTABLE`.
  - Run with configured interpreter first, fallback to `py` if needed.
- Windows CMake safety checks:
  - Added ABI mismatch validation in:
    - `DdsRecorderCommand/CMakeLists.txt`
    - `DdsRecorderStatus/CMakeLists.txt`