### PR TITLE
[#24429] Fix Windows CI vcpkg cache environment for MCAP dependencies

### DIFF
--- a/.github/actions/install_mcap_dependencies/action.yml
+++ b/.github/actions/install_mcap_dependencies/action.yml
@@ -27,6 +27,21 @@ runs:
       run: |
         git clone https://github.com/Microsoft/vcpkg.git ${{ github.workspace }}\vcpkg
 
+    - name: Prepare vcpkg GitHub cache environment
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $gha_cache_url = $env:ACTIONS_CACHE_URL
+        if ([string]::IsNullOrWhiteSpace($gha_cache_url) -and -not [string]::IsNullOrWhiteSpace($env:ACTIONS_RESULTS_URL)) {
+          $gha_cache_url = $env:ACTIONS_RESULTS_URL
+          "ACTIONS_CACHE_URL=$gha_cache_url" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        }
+
+        if ([string]::IsNullOrWhiteSpace($env:ACTIONS_RUNTIME_TOKEN) -or [string]::IsNullOrWhiteSpace($gha_cache_url)) {
+          "VCPKG_BINARY_SOURCES=clear" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host 'GitHub Actions cache variables are unavailable for vcpkg. Falling back to local binary caching.'
+        }
+
     - name: Install vcpkg
       if: runner.os == 'Windows'
       uses: lukka/run-vcpkg@v11


### PR DESCRIPTION
## Description

This PR fixes the Windows GitHub Actions failure when installing MCAP dependencies with `vcpkg`.

Changes included:
- add a Windows prep step before `lukka/run-vcpkg`
- map `ACTIONS_RESULTS_URL` to `ACTIONS_CACHE_URL` when the runner exposes the newer variable name
- fall back to `VCPKG_BINARY_SOURCES=clear` when the GitHub cache environment is incomplete