### PR TITLE
[#24574] Fix macOS build issues in YAML parsing and CLI arguments

### DIFF
--- a/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsrecorder/src/cpp/user_interface/arguments_configuration.cpp
@@ -116,7 +116,7 @@ const option::Descriptor usage[] = {
     },
 
     {
-        optionIndex::DOMAIN,
+        optionIndex::DOMAIN_ID,
         0,
         "",
         "domain",
@@ -272,7 +272,7 @@ ProcessReturnCode parse_arguments(
                     commandline_args.timeout = std::stol(opt.arg) * 1000; // pass to milliseconds
                     break;
 
-                case optionIndex::DOMAIN:
+                case optionIndex::DOMAIN_ID:
                 {
                     const auto max_domain_id = static_cast<long>(ddspipe::core::types::DomainId::MAX_DOMAIN_ID);
                     long domain_value = 0;

--- a/ddsrecorder/src/cpp/user_interface/arguments_configuration.hpp
+++ b/ddsrecorder/src/cpp/user_interface/arguments_configuration.hpp
@@ -100,7 +100,7 @@ enum optionIndex
     TIMEOUT,
     LOG_FILTER,
     LOG_VERBOSITY,
-    DOMAIN,
+    DOMAIN_ID,
 };
 
 /**

--- a/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
+++ b/ddsrecorder_yaml/src/cpp/recorder/YamlReaderConfiguration.cpp
@@ -674,11 +674,9 @@ void RecorderConfiguration::load_dds_configuration_(
 
         for (const auto& topic : manual_topics)
         {
-            const std::string key(topic.first->topic_name);
+            const std::string key(topic.first->topic_name.get_reference());
 
-            // Force an unambiguous std::string
-            const std::string filter =
-                    static_cast<std::string>(topic.first->content_topic_filter);
+            const std::string filter = topic.first->content_topic_filter.get_reference();
 
             auto ret = dds_configuration->content_topic_filter_dict.insert(
                 std::make_pair(key, filter));

--- a/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
+++ b/ddsreplayer/src/cpp/user_interface/arguments_configuration.cpp
@@ -114,7 +114,7 @@ const option::Descriptor usage[] = {
     },
 
     {
-        optionIndex::DOMAIN,
+        optionIndex::DOMAIN_ID,
         0,
         "",
         "domain",
@@ -263,7 +263,7 @@ ProcessReturnCode parse_arguments(
                     commandline_args.reload_time = std::stol(opt.arg) * 1000; // pass to milliseconds
                     break;
 
-                case optionIndex::DOMAIN:
+                case optionIndex::DOMAIN_ID:
                 {
                     const auto max_domain_id = static_cast<long>(ddspipe::core::types::DomainId::MAX_DOMAIN_ID);
                     long domain_value = 0;

--- a/ddsreplayer/src/cpp/user_interface/arguments_configuration.hpp
+++ b/ddsreplayer/src/cpp/user_interface/arguments_configuration.hpp
@@ -100,7 +100,7 @@ enum optionIndex
     VERSION,
     LOG_FILTER,
     LOG_VERBOSITY,
-    DOMAIN,
+    DOMAIN_ID,
 };
 
 /**


### PR DESCRIPTION
## Description

This PR fixes two macOS compilation issues in DDS-Record-Replay.

## Changes

1. Make `std::string` extraction explicit in `ddsrecorder_yaml` by using `get_reference()` instead of relying on implicit conversion from `utils::Fuzzy<std::string>`.
2. Rename the CLI option enum entry `DOMAIN` to `DOMAIN_ID` in `ddsrecord_tool` and `ddsreplay_tool` to avoid colliding with the `DOMAIN` macro defined by macOS system headers.

## Errors

### 1. 
```bash
--- stderr: fastddsspy_yaml                             
/Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp:189:31: error: call to constructor of 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char>>') is ambiguous
  189 |             const std::string key(topic.first->topic_name);
      |                               ^   ~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:822:5: note: candidate constructor
  822 |     basic_string(const basic_string& __str);
      |     ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:827:5: note: candidate constructor
  827 |     basic_string(basic_string&& __str)
      |     ^
/Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_yaml/src/cpp/YamlReaderConfiguration.cpp:193:21: error: ambiguous conversion for static_cast from 'utils::Fuzzy<std::string>' (aka 'Fuzzy<basic_string<char, char_traits<char>, allocator<char>>>') to 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char>>')
  193 |                     static_cast<std::string>(topic.first->content_topic_filter);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:822:5: note: candidate constructor
  822 |     basic_string(const basic_string& __str);
      |     ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:827:5: note: candidate constructor
  827 |     basic_string(basic_string&& __str)
```

### 2.
```bash
In file included from /Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp:30:
/Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.hpp:102:5: error: expected identifier
  102 |     DOMAIN,
      |     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/math.h:781:17: note: expanded from macro 'DOMAIN'
  781 | #define DOMAIN          1
      |                         ^
/Users/macmini/workspace_dev_utils/src/Fast-DDS-Spy/fastddsspy_tool/src/cpp/user_interface/arguments_configuration.cpp:105:22: error: expected unqualified-id
  105 |         optionIndex::DOMAIN,
```