### PR TITLE
[#24585] Remove v2 nightly

### DIFF
--- a/.github/actions/project_dependencies/action.yml
+++ b/.github/actions/project_dependencies/action.yml
@@ -14,7 +14,7 @@ inputs:
   custom_version_build:
     description: >
       Use the custom version build from eProsima-CI.
-      If set to false, the workflow will run the tests for Fast DDS v2 and v3.
+      If set to false, the workflow will run the tests for Fast DDS v3.
     required: true
     default: 'custom'
 

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -9,15 +9,6 @@ on:
 
 jobs:
 
-  reusable_tests_v2:
-    name: reusable_tests_v2
-    uses: ./.github/workflows/reusable-ubuntu-ci.yml
-    with:
-      custom_version_build: 'v2'
-      dependencies_artifact_postfix: '_nightly'
-      ref: '0.x'
-    secrets: inherit
-
   reusable_tests_v3:
     name: reusable_tests_v3
     uses: ./.github/workflows/reusable-ubuntu-ci.yml

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -9,15 +9,6 @@ on:
 
 jobs:
 
-  reusable_tests_v2:
-    name: reusable_tests_v2
-    uses: ./.github/workflows/reusable-windows-ci.yml
-    with:
-      custom_version_build: 'v2'
-      dependencies_artifact_postfix: '_nightly'
-      ref: '0.x'
-    secrets: inherit
-
   reusable_tests_v3:
     name: reusable_tests_v3
     uses: ./.github/workflows/reusable-windows-ci.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,12 @@ on:
       custom_version_build:
         description: >
           Use the custom version build from eProsima-CI.
-          If set to false, the workflow will run the tests for Fast DDS v2 and v3.
+          If set to false, the workflow will run the tests for Fast DDS v3.
         required: true
         type: choice
         default: 'custom'
         options:
           - custom
-          - v2
           - v3
 
       dependencies_artifact_postfix:


### PR DESCRIPTION
## Description

Remove the Fast DDS v2 nightly jobs from the CI matrix. Only Fast DDS v3 is exercised nightly going forward. 

The v2 nightly has become chronically flaky: tests in `McapFileCreationTest` and `ResourceLimitsTest` fail intermittently under TSAN due to data races inside upstream Fast DDS v2 itself.


## New Nightlies

### [nightly-ubuntu-ci](https://github.com/eProsima/DDS-Record-Replay/actions/runs/26803814846) 🟢
### [nightly-windows-ci](https://github.com/eProsima/DDS-Record-Replay/actions/runs/26803800168) 🟢
