### PR TITLE
[#25452] Improve `mcap-convert` tool performance with batched parallel processing

### DIFF
--- a/converter/mcap_convert_tool/src/cpp/main.cpp
+++ b/converter/mcap_convert_tool/src/cpp/main.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <exception>
 #include <memory>
 
@@ -93,10 +94,16 @@ int main(
         eprosima::ddsrecorder::converter::McapToSqlConverter converter(
             *configuration,
             commandline_args.input_file,
-            output_file);
+            output_file,
+            commandline_args.sql_batch_size);
+        const auto conversion_start = std::chrono::steady_clock::now();
         converter.convert();
+        const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - conversion_start);
 
-        logUser(DDSREPLAYER_EXECUTION, "MCAP-to-SQL conversion finished correctly.");
+        logUser(
+            DDSREPLAYER_EXECUTION,
+            "MCAP-to-SQL conversion finished correctly in " << elapsed_ms.count() << " ms.");
         logUser(DDSREPLAYER_EXECUTION, "Finishing MCAP Convert execution correctly.");
 
         eprosima::utils::Log::Flush();

--- a/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.cpp
+++ b/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.cpp
@@ -206,12 +206,12 @@ void write_topic_metadata_(
 {
     if (written_topics.insert(topic).second)
     {
-        sql_writer.write(topic);
+        sql_writer.write_topic(topic);
     }
 
     if (written_partitions.insert(partition).second)
     {
-        sql_writer.write(partition);
+        sql_writer.write_partition_name(partition);
     }
 
     const auto topic_partition_key = topic.topic_name() + topic.type_name + partition;
@@ -523,7 +523,7 @@ void McapToSqlConverter::convert()
 
                     // SQLite writes stay serialized; only the expensive message
                     // hydration step is parallelized.
-                    sql_writer.write(pending_messages);
+                    sql_writer.write_messages(pending_messages);
                     pending_messages.clear();
                     pending_type_names.clear();
                 };

--- a/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.cpp
+++ b/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.cpp
@@ -18,17 +18,22 @@
 #include <cctype>
 #include <exception>
 #include <filesystem>
+#include <future>
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include <mcap/reader.hpp>
 
 #include <fastdds/dds/core/Time_t.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/DynamicDataFactory.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicPubSubType.hpp>
+#include <fastdds/dds/xtypes/utils.hpp>
 
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/Formatter.hpp>
@@ -40,6 +45,7 @@
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 
 #include <ddsrecorder_participants/common/types/dynamic_types_collection/DynamicTypesCollection.hpp>
+#include <ddsrecorder_participants/common/time_utils.hpp>
 #include <ddsrecorder_participants/constants.hpp>
 #include <ddsrecorder_participants/recorder/handler/sql/SqlWriter.hpp>
 #include <ddsrecorder_participants/recorder/message/SqlMessage.hpp>
@@ -53,6 +59,25 @@ namespace ddsrecorder {
 namespace converter {
 
 namespace {
+
+constexpr auto kSqlWriteBatchSize = 4096u;
+constexpr auto kMinMessagesPerWorker = 512u;
+
+struct DynamicSerializationContext
+{
+    explicit DynamicSerializationContext(
+            const fastdds::dds::DynamicType::_ref_type& dynamic_type_ref)
+        : dynamic_type(dynamic_type_ref)
+        , pub_sub_type(dynamic_type_ref)
+        , dynamic_data(fastdds::dds::DynamicDataFactory::get_instance()->create_data(dynamic_type_ref))
+    {
+    }
+
+    fastdds::dds::DynamicType::_ref_type dynamic_type;
+    fastdds::dds::DynamicPubSubType pub_sub_type;
+    fastdds::dds::DynamicData::_ref_type dynamic_data;
+    std::stringstream json_stream;
+};
 
 class McapReaderParticipantAccessor : public participants::McapReaderParticipant
 {
@@ -69,6 +94,29 @@ public:
             const std::string& file_path)
         : participants::McapReaderParticipant(configuration, payload_pool, file_path)
     {
+    }
+
+    mcap::LinearMessageView read_mcap_messages_file_order_()
+    {
+        const mcap::Timestamp begin_time =
+                configuration_->begin_time.is_set() ?
+                participants::to_mcap_timestamp(configuration_->begin_time.get_reference()) :
+                0;
+
+        const mcap::Timestamp end_time =
+                configuration_->end_time.is_set() ?
+                participants::to_mcap_timestamp(configuration_->end_time.get_reference()) :
+                mcap::MaxTime;
+
+        mcap::ReadMessageOptions read_options(begin_time, end_time);
+        read_options.readOrder = mcap::ReadMessageOptions::ReadOrder::FileOrder;
+
+        return mcap_reader_.readMessages([](const mcap::Status& status)
+                       {
+                           EPROSIMA_LOG_WARNING(
+                               DDSREPLAYER_MCAP_READER_PARTICIPANT,
+                               "An error occurred while reading MCAP messages: " << status.message << ".");
+                       }, read_options);
     }
 
     const std::set<std::string>& filtered_writersguid_list() const noexcept
@@ -237,12 +285,43 @@ participants::OutputSettings create_output_settings_(
 }
 
 bool compute_instance_handle_(
-        const fastdds::dds::DynamicType::_ref_type& dynamic_type,
+        DynamicSerializationContext& serialization_context,
         ddspipe::core::types::Payload& payload,
         ddspipe::core::types::InstanceHandle& instance_handle)
 {
-    fastdds::dds::DynamicPubSubType pub_sub_type(dynamic_type);
-    return pub_sub_type.compute_key(payload, instance_handle);
+    return serialization_context.pub_sub_type.compute_key(payload, instance_handle);
+}
+
+void deserialize_payload_to_json_(
+        participants::SqlMessage& sql_message,
+        DynamicSerializationContext& serialization_context)
+{
+    if (!sql_message.data_json.empty())
+    {
+        return;
+    }
+
+    if (!serialization_context.pub_sub_type.deserialize(sql_message.payload, &serialization_context.dynamic_data))
+    {
+        EPROSIMA_LOG_WARNING(SQL_MESSAGE, "Failed to deserialize payload into DynamicData.");
+        return;
+    }
+
+    serialization_context.json_stream.str("");
+    serialization_context.json_stream.clear();
+
+    const auto ret = fastdds::dds::json_serialize(
+        serialization_context.dynamic_data,
+        fastdds::dds::DynamicDataJsonFormat::EPROSIMA,
+        serialization_context.json_stream);
+
+    if (ret != fastdds::dds::RETCODE_OK)
+    {
+        EPROSIMA_LOG_WARNING(SQL_MESSAGE, "Failed to serialize payload into JSON");
+        return;
+    }
+
+    sql_message.data_json = serialization_context.json_stream.str();
 }
 
 } // namespace
@@ -305,12 +384,149 @@ void McapToSqlConverter::convert()
     std::set<ddspipe::core::types::DdsTopic> written_topics;
     std::set<std::string> written_partitions;
     std::set<std::string> written_topic_partitions;
-    std::map<ddspipe::core::types::InstanceHandle, std::string> keys_by_instance_handle;
+    std::vector<participants::SqlMessage> pending_messages;
+    std::vector<std::string> pending_type_names;
+
+    pending_messages.reserve(kSqlWriteBatchSize);
+    pending_type_names.reserve(kSqlWriteBatchSize);
 
     sql_writer.enable();
 
     try
     {
+        // Prepares a slice of messages
+        const auto hydrate_message_range = [
+                &pending_messages, // messages (ith)
+                &pending_type_names, // dynamic_types for the message (ith)
+                &dynamic_types_by_name // lookup table from type_name to dynamic_type
+            ](const std::size_t begin, const std::size_t end) // Indices (example 0-512
+                {
+                    // Each worker keeps its own caches to avoid sharing mutable
+                    // DynamicData/key state across threads
+                    std::map<ddspipe::core::types::InstanceHandle, std::string> keys_by_instance_handle;
+                    std::map<std::string, DynamicSerializationContext> serialization_contexts;
+                    
+                    // Create the serialization context for types. Reducing the construction in every message
+                    for (const auto& [type_name, dynamic_type] : dynamic_types_by_name)
+                    {
+                        serialization_contexts.try_emplace(type_name, dynamic_type);
+                    }
+                    
+                    // -- Messages --------------------------------------------
+                    for (int i = begin; i < end; i++)
+                    {
+                        // SQL
+                        auto& sql_message = pending_messages[i];
+                        // timestamps
+                        sql_message.log_time_sql = participants::to_sql_timestamp(sql_message.log_time);
+                        sql_message.publish_time_sql = participants::to_sql_timestamp(sql_message.publish_time);
+
+                        if (pending_type_names[i].empty())
+                        {
+                            // No type, it ca not be reconstructed
+                            continue;
+                        }
+                        
+                        // Message type and context
+                        const auto dynamic_type_it = dynamic_types_by_name.find(pending_type_names[i]);
+                        auto serialization_context_it = serialization_contexts.find(pending_type_names[i]);
+
+                        if (dynamic_type_it == dynamic_types_by_name.end() ||
+                                serialization_context_it == serialization_contexts.end())
+                        {
+                            // It does not exists.
+                            continue;
+                        }
+
+                        // Instance id
+                        const auto has_instance_handle = compute_instance_handle_(
+                            serialization_context_it->second,
+                            sql_message.payload,
+                            sql_message.instance_handle);
+
+                        deserialize_payload_to_json_(sql_message, serialization_context_it->second);
+
+                        const auto key_it = has_instance_handle ?
+                                keys_by_instance_handle.find(sql_message.instance_handle) :
+                                keys_by_instance_handle.end();
+
+                        if (has_instance_handle && key_it != keys_by_instance_handle.end())
+                        {
+                            sql_message.key = key_it->second;
+                        }
+                        else
+                        {
+                            sql_message.set_key(dynamic_type_it->second);
+                            if (has_instance_handle)
+                            {
+                                keys_by_instance_handle[sql_message.instance_handle] = sql_message.key;
+                            }
+                        }
+                    }
+                };
+        
+        // Run the preparation (possibly in parallel) and write the batch of messages in the SQL file
+        const auto flush_pending_messages =
+                [&pending_messages, &pending_type_names, &hydrate_message_range, &sql_writer]()
+                {
+                    if (pending_messages.empty())
+                    {
+                        return;
+                    }
+
+                    // Get the number of threads in the computer
+                    const auto hardware_threads = std::max(1u, std::thread::hardware_concurrency());
+                    // 1. Do not use more threads than cores the computer has
+                    // 2. Do not create threads if the slice is small
+                    const auto worker_count = std::max<std::size_t>(
+                        1u,
+                        std::min<std::size_t>(
+                            hardware_threads, // 1. 
+                            (pending_messages.size() + kMinMessagesPerWorker - 1) / kMinMessagesPerWorker)); // 2.
+
+                    if (worker_count == 1)
+                    {
+                        // Small slice, only 1 thread, avoid overhead
+                        hydrate_message_range(0, pending_messages.size());
+                    }
+                    else
+                    {
+                        // Divide it in similar size slices                        
+                        const auto slice_size = (pending_messages.size() + worker_count - 1) / worker_count;
+                        // Futures for each async jobg
+                        std::vector<std::future<void>> futures;
+                        futures.reserve(worker_count);
+
+                        for (int i = 0; i < worker_count; i++)
+                        {
+                            const auto begin = i * slice_size;
+                            if (begin >= pending_messages.size())
+                            {
+                                break;
+                            }
+
+                            const auto end = std::min(pending_messages.size(), begin + slice_size);
+                            futures.push_back(std::async(
+                                        std::launch::async,
+                                        [&, begin, end]()
+                                        {
+                                            hydrate_message_range(begin, end);
+                                        }));
+                        }
+
+                        for (auto& future : futures)
+                        {
+                            future.get();
+                        }
+                    }
+
+                    // SQLite writes stay serialized; only the expensive message
+                    // hydration step is parallelized.
+                    sql_writer.write(pending_messages);
+                    pending_messages.clear();
+                    pending_type_names.clear();
+                };
+
         std::set<std::string> dynamic_type_names;
         for (const auto& dynamic_type : dynamic_types_collection.dynamic_types())
         {
@@ -328,7 +544,7 @@ void McapToSqlConverter::convert()
         }
 
         reader.open_file_();
-        auto messages = reader.read_mcap_messages_();
+        auto messages = reader.read_mcap_messages_file_order_();
 
         if (messages.begin() == messages.end())
         {
@@ -361,11 +577,8 @@ void McapToSqlConverter::convert()
             auto data = reader.create_payload_(message.message.data, message.message.dataSize);
             data->source_guid = to_guid_(writer_guid_str);
 
-            const auto dynamic_type_it = dynamic_types_by_name.find(topic_it->second.type_name);
-            const auto has_instance_handle = dynamic_type_it != dynamic_types_by_name.end() &&
-                    compute_instance_handle_(dynamic_type_it->second, data->payload, data->instanceHandle);
-
             participants::SqlMessage sql_message(*data, reader.payload_pool(), topic_it->second);
+            sql_message.writer_guid_string = writer_guid_str;
             sql_message.sequence_number = fastdds::rtps::SequenceNumber_t(
                 static_cast<uint64_t>(message.message.sequence));
             sql_message.log_time = fastdds::dds::Time_t(
@@ -374,16 +587,17 @@ void McapToSqlConverter::convert()
             sql_message.publish_time = fastdds::dds::Time_t(
                 static_cast<int32_t>(message.message.publishTime / 1000000000ULL),
                 static_cast<uint32_t>(message.message.publishTime % 1000000000ULL));
+            sql_message.partition = get_writer_partition_(sql_message.topic, writer_guid_str);
 
-            const auto partition = get_writer_partition_(sql_message.topic, writer_guid_str);
             write_topic_metadata_(
                 sql_writer,
                 sql_message.topic,
-                partition,
+                sql_message.partition,
                 written_topics,
                 written_partitions,
                 written_topic_partitions);
 
+            const auto dynamic_type_it = dynamic_types_by_name.find(topic_it->second.type_name);
             if (dynamic_type_it == dynamic_types_by_name.end())
             {
                 EPROSIMA_LOG_WARNING(
@@ -391,32 +605,22 @@ void McapToSqlConverter::convert()
                     "Type information for topic " << sql_message.topic.topic_name()
                                                   << " with type " << sql_message.topic.type_name
                                                   << " is not available. Storing only CDR payload.");
+                pending_type_names.emplace_back();
             }
             else
             {
-                sql_message.deserialize(dynamic_type_it->second);
-
-                const auto key_it = has_instance_handle ?
-                        keys_by_instance_handle.find(sql_message.instance_handle) :
-                        keys_by_instance_handle.end();
-
-                if (has_instance_handle && key_it != keys_by_instance_handle.end())
-                {
-                    sql_message.key = key_it->second;
-                }
-                else
-                {
-                    sql_message.set_key(dynamic_type_it->second);
-                    if (has_instance_handle)
-                    {
-                        keys_by_instance_handle[sql_message.instance_handle] = sql_message.key;
-                    }
-                }
+                pending_type_names.push_back(dynamic_type_it->first);
             }
 
-            sql_writer.write(std::vector<participants::SqlMessage>{sql_message});
+            pending_messages.push_back(sql_message);
+
+            if (pending_messages.size() == kSqlWriteBatchSize)
+            {
+                flush_pending_messages();
+            }
         }
 
+        flush_pending_messages();
         reader.close_file_();
         sql_writer.disable();
     }

--- a/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.cpp
+++ b/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.cpp
@@ -60,7 +60,6 @@ namespace converter {
 
 namespace {
 
-constexpr auto kSqlWriteBatchSize = 4096u;
 constexpr auto kMinMessagesPerWorker = 512u;
 
 struct DynamicSerializationContext
@@ -329,10 +328,12 @@ void deserialize_payload_to_json_(
 McapToSqlConverter::McapToSqlConverter(
         const yaml::ReplayerConfiguration& configuration,
         const std::string& input_file,
-        const std::string& output_file)
+        const std::string& output_file,
+        const std::size_t batch_size)
     : configuration_(configuration)
     , input_file_(input_file)
     , output_file_(resolve_output_file(input_file, output_file))
+    , batch_size_(batch_size)
 {
 }
 
@@ -387,8 +388,8 @@ void McapToSqlConverter::convert()
     std::vector<participants::SqlMessage> pending_messages;
     std::vector<std::string> pending_type_names;
 
-    pending_messages.reserve(kSqlWriteBatchSize);
-    pending_type_names.reserve(kSqlWriteBatchSize);
+    pending_messages.reserve(batch_size_);
+    pending_type_names.reserve(batch_size_);
 
     sql_writer.enable();
 
@@ -396,22 +397,22 @@ void McapToSqlConverter::convert()
     {
         // Prepares a slice of messages
         const auto hydrate_message_range = [
-                &pending_messages, // messages (ith)
-                &pending_type_names, // dynamic_types for the message (ith)
-                &dynamic_types_by_name // lookup table from type_name to dynamic_type
-            ](const std::size_t begin, const std::size_t end) // Indices (example 0-512
+            &pending_messages,     // messages (ith)
+            &pending_type_names,     // dynamic_types for the message (ith)
+            &dynamic_types_by_name     // lookup table from type_name to dynamic_type
+                ](const std::size_t begin, const std::size_t end) // Indices (example 0-512
                 {
                     // Each worker keeps its own caches to avoid sharing mutable
                     // DynamicData/key state across threads
                     std::map<ddspipe::core::types::InstanceHandle, std::string> keys_by_instance_handle;
                     std::map<std::string, DynamicSerializationContext> serialization_contexts;
-                    
+
                     // Create the serialization context for types. Reducing the construction in every message
                     for (const auto& [type_name, dynamic_type] : dynamic_types_by_name)
                     {
                         serialization_contexts.try_emplace(type_name, dynamic_type);
                     }
-                    
+
                     // -- Messages --------------------------------------------
                     for (int i = begin; i < end; i++)
                     {
@@ -426,7 +427,7 @@ void McapToSqlConverter::convert()
                             // No type, it ca not be reconstructed
                             continue;
                         }
-                        
+
                         // Message type and context
                         const auto dynamic_type_it = dynamic_types_by_name.find(pending_type_names[i]);
                         auto serialization_context_it = serialization_contexts.find(pending_type_names[i]);
@@ -464,7 +465,7 @@ void McapToSqlConverter::convert()
                         }
                     }
                 };
-        
+
         // Run the preparation (possibly in parallel) and write the batch of messages in the SQL file
         const auto flush_pending_messages =
                 [&pending_messages, &pending_type_names, &hydrate_message_range, &sql_writer]()
@@ -481,7 +482,7 @@ void McapToSqlConverter::convert()
                     const auto worker_count = std::max<std::size_t>(
                         1u,
                         std::min<std::size_t>(
-                            hardware_threads, // 1. 
+                            hardware_threads, // 1.
                             (pending_messages.size() + kMinMessagesPerWorker - 1) / kMinMessagesPerWorker)); // 2.
 
                     if (worker_count == 1)
@@ -491,7 +492,7 @@ void McapToSqlConverter::convert()
                     }
                     else
                     {
-                        // Divide it in similar size slices                        
+                        // Divide it in similar size slices
                         const auto slice_size = (pending_messages.size() + worker_count - 1) / worker_count;
                         // Futures for each async jobg
                         std::vector<std::future<void>> futures;
@@ -614,7 +615,7 @@ void McapToSqlConverter::convert()
 
             pending_messages.push_back(sql_message);
 
-            if (pending_messages.size() == kSqlWriteBatchSize)
+            if (pending_messages.size() == batch_size_)
             {
                 flush_pending_messages();
             }

--- a/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.cpp
+++ b/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.cpp
@@ -60,7 +60,7 @@ namespace converter {
 
 namespace {
 
-constexpr auto kMinMessagesPerWorker = 512u;
+constexpr auto MIN_MESSAGES_PER_WORKER = 512u;
 
 struct DynamicSerializationContext
 {
@@ -400,7 +400,7 @@ void McapToSqlConverter::convert()
             &pending_messages,     // messages (ith)
             &pending_type_names,     // dynamic_types for the message (ith)
             &dynamic_types_by_name     // lookup table from type_name to dynamic_type
-                ](const std::size_t begin, const std::size_t end) // Indices (example 0-512
+                ](const std::size_t begin, const std::size_t end) // Indices (example 0-512)
                 {
                     // Each worker keeps its own caches to avoid sharing mutable
                     // DynamicData/key state across threads
@@ -414,7 +414,7 @@ void McapToSqlConverter::convert()
                     }
 
                     // -- Messages --------------------------------------------
-                    for (int i = begin; i < end; i++)
+                    for (std::size_t i = begin; i < end; i++)
                     {
                         // SQL
                         auto& sql_message = pending_messages[i];
@@ -424,7 +424,7 @@ void McapToSqlConverter::convert()
 
                         if (pending_type_names[i].empty())
                         {
-                            // No type, it ca not be reconstructed
+                            // No type, it cannot be reconstructed
                             continue;
                         }
 
@@ -483,7 +483,7 @@ void McapToSqlConverter::convert()
                         1u,
                         std::min<std::size_t>(
                             hardware_threads, // 1.
-                            (pending_messages.size() + kMinMessagesPerWorker - 1) / kMinMessagesPerWorker)); // 2.
+                            (pending_messages.size() + MIN_MESSAGES_PER_WORKER - 1) / MIN_MESSAGES_PER_WORKER)); // 2.
 
                     if (worker_count == 1)
                     {
@@ -494,11 +494,11 @@ void McapToSqlConverter::convert()
                     {
                         // Divide it in similar size slices
                         const auto slice_size = (pending_messages.size() + worker_count - 1) / worker_count;
-                        // Futures for each async jobg
+                        // Futures for each async job
                         std::vector<std::future<void>> futures;
                         futures.reserve(worker_count);
 
-                        for (int i = 0; i < worker_count; i++)
+                        for (std::size_t i = 0; i < worker_count; i++)
                         {
                             const auto begin = i * slice_size;
                             if (begin >= pending_messages.size())

--- a/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.hpp
+++ b/converter/mcap_convert_tool/src/cpp/tool/McapToSqlConverter.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include <ddsrecorder_yaml/replayer/YamlReaderConfiguration.hpp>
@@ -29,7 +30,8 @@ public:
     McapToSqlConverter(
             const yaml::ReplayerConfiguration& configuration,
             const std::string& input_file,
-            const std::string& output_file = "");
+            const std::string& output_file = "",
+            const std::size_t batch_size = 4096u);
 
     void convert();
 
@@ -42,6 +44,7 @@ protected:
     const yaml::ReplayerConfiguration& configuration_;
     const std::string input_file_;
     const std::string output_file_;
+    const std::size_t batch_size_;
 };
 
 } /* namespace converter */

--- a/converter/mcap_convert_tool/src/cpp/user_interface/CommandlineArgsMcapConvert.hpp
+++ b/converter/mcap_convert_tool/src/cpp/user_interface/CommandlineArgsMcapConvert.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include <ddsrecorder_yaml/replayer/CommandlineArgsReplayer.hpp>
@@ -25,6 +26,7 @@ namespace converter {
 struct CommandlineArgsMcapConvert : public yaml::CommandlineArgsReplayer
 {
     std::string sql_output{""};
+    std::size_t sql_batch_size{4096u};
 
     bool is_valid(
             utils::Formatter& error_msg) const noexcept override
@@ -32,6 +34,12 @@ struct CommandlineArgsMcapConvert : public yaml::CommandlineArgsReplayer
         if (input_file.empty())
         {
             error_msg << "Option '-i' / '--input-file' is required.";
+            return false;
+        }
+
+        if (sql_batch_size == 0)
+        {
+            error_msg << "Option '--sql-batch-size' must be greater than 0.";
             return false;
         }
 

--- a/converter/mcap_convert_tool/src/cpp/user_interface/CommandlineArgsMcapConvert.hpp
+++ b/converter/mcap_convert_tool/src/cpp/user_interface/CommandlineArgsMcapConvert.hpp
@@ -37,9 +37,18 @@ struct CommandlineArgsMcapConvert : public yaml::CommandlineArgsReplayer
             return false;
         }
 
+        constexpr std::size_t MAX_SQL_BATCH_SIZE = 160000001u;
+
         if (sql_batch_size == 0)
         {
             error_msg << "Option '--sql-batch-size' must be greater than 0.";
+            return false;
+        }
+
+        if (sql_batch_size > MAX_SQL_BATCH_SIZE)
+        {
+            error_msg << "Option '--sql-batch-size' (" << sql_batch_size
+                      << ") exceeds maximum allowed value (" << MAX_SQL_BATCH_SIZE << ").";
             return false;
         }
 

--- a/converter/mcap_convert_tool/src/cpp/user_interface/arguments_configuration.cpp
+++ b/converter/mcap_convert_tool/src/cpp/user_interface/arguments_configuration.cpp
@@ -103,6 +103,16 @@ const option::Descriptor usage[] = {
     },
 
     {
+        optionIndex::SQL_BATCH_SIZE,
+        0,
+        "",
+        "sql-batch-size",
+        Arg::Numeric,
+        "  \t--sql-batch-size\t  \t" \
+        "Batch size used for SQL conversion. [Default: 4096]."
+    },
+
+    {
         optionIndex::UNKNOWN_OPT, 0, "", "", Arg::None,
         "\nDebug parameters"
     },
@@ -233,6 +243,10 @@ ProcessReturnCode parse_arguments(
                     commandline_args.sql_output = opt.arg;
                     break;
 
+                case optionIndex::SQL_BATCH_SIZE:
+                    commandline_args.sql_batch_size = static_cast<std::size_t>(std::strtoull(opt.arg, nullptr, 10));
+                    break;
+
                 case optionIndex::ACTIVATE_DEBUG:
                     commandline_args.log_filter[utils::VerbosityKind::Error].set_value("");
                     commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("DDSREPLAYER");
@@ -304,6 +318,26 @@ option::ArgStatus Arg::Required(
     {
         EPROSIMA_LOG_ERROR(DDSREPLAYER_ARGS, "Option '" << option << "' required.");
     }
+    return option::ARG_ILLEGAL;
+}
+
+option::ArgStatus Arg::Numeric(
+        const option::Option& option,
+        bool msg)
+{
+    char* endptr = nullptr;
+    std::strtoull(option.arg, &endptr, 10);
+
+    if (option.arg != nullptr && endptr != option.arg && *endptr == 0)
+    {
+        return option::ARG_OK;
+    }
+
+    if (msg)
+    {
+        EPROSIMA_LOG_ERROR(DDSREPLAYER_ARGS, "Option '" << option << "' requires a numeric argument.");
+    }
+
     return option::ARG_ILLEGAL;
 }
 

--- a/converter/mcap_convert_tool/src/cpp/user_interface/arguments_configuration.cpp
+++ b/converter/mcap_convert_tool/src/cpp/user_interface/arguments_configuration.cpp
@@ -15,6 +15,7 @@
 #include "arguments_configuration.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
@@ -325,6 +326,47 @@ option::ArgStatus Arg::Numeric(
         const option::Option& option,
         bool msg)
 {
+    if (option.arg == nullptr || option.arg[0] == 0)
+    {
+        if (msg)
+        {
+            EPROSIMA_LOG_ERROR(DDSREPLAYER_ARGS, "Option '" << option << "' requires a numeric argument.");
+        }
+
+        return option::ARG_ILLEGAL;
+    }
+
+    const auto* value = option.arg;
+    if (*value == '+')
+    {
+        ++value;
+    }
+
+    if (*value == 0 || *value == '-')
+    {
+        if (msg)
+        {
+            EPROSIMA_LOG_ERROR(
+                DDSREPLAYER_ARGS,
+                "Option '" << option << "' requires a positive numeric argument.");
+        }
+
+        return option::ARG_ILLEGAL;
+    }
+
+    for (const auto* it = value; *it != 0; ++it)
+    {
+        if (!std::isdigit(static_cast<unsigned char>(*it)))
+        {
+            if (msg)
+            {
+                EPROSIMA_LOG_ERROR(DDSREPLAYER_ARGS, "Option '" << option << "' requires a numeric argument.");
+            }
+
+            return option::ARG_ILLEGAL;
+        }
+    }
+
     char* endptr = nullptr;
     std::strtoull(option.arg, &endptr, 10);
 

--- a/converter/mcap_convert_tool/src/cpp/user_interface/arguments_configuration.hpp
+++ b/converter/mcap_convert_tool/src/cpp/user_interface/arguments_configuration.hpp
@@ -44,6 +44,10 @@ struct Arg : public option::Arg
             const option::Option& option,
             bool msg);
 
+    static option::ArgStatus Numeric(
+            const option::Option& option,
+            bool msg);
+
     static option::ArgStatus String(
             const option::Option& option,
             bool msg);
@@ -70,6 +74,7 @@ enum optionIndex
     INPUT_FILE,
     CONFIGURATION_FILE,
     SQL_OUTPUT,
+    SQL_BATCH_SIZE,
     ACTIVATE_DEBUG,
     LOG_FILTER,
     LOG_VERBOSITY,

--- a/converter/mcap_convert_tool/test/blackbox/CMakeLists.txt
+++ b/converter/mcap_convert_tool/test/blackbox/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_LIST
     missing_input
     custom_sql_batch_size_argument
     zero_sql_batch_size_argument_is_invalid
+    negative_sql_batch_size_argument_is_invalid
     default_output
     explicit_output
     ros2_output_exact_counts

--- a/converter/mcap_convert_tool/test/blackbox/CMakeLists.txt
+++ b/converter/mcap_convert_tool/test/blackbox/CMakeLists.txt
@@ -22,9 +22,12 @@ set(TEST_LIST
     help_argument
     version_argument
     missing_input
+    custom_sql_batch_size_argument
+    zero_sql_batch_size_argument_is_invalid
     default_output
     explicit_output
     ros2_output_exact_counts
+    ros2_output_exact_counts_with_small_batch
 )
 
 set(TEST_NEEDED_SOURCES

--- a/converter/mcap_convert_tool/test/blackbox/CMakeLists.txt
+++ b/converter/mcap_convert_tool/test/blackbox/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_LIST
     missing_input
     default_output
     explicit_output
+    ros2_output_exact_counts
 )
 
 set(TEST_NEEDED_SOURCES

--- a/converter/mcap_convert_tool/test/blackbox/McapConvertTest.cpp
+++ b/converter/mcap_convert_tool/test/blackbox/McapConvertTest.cpp
@@ -149,6 +149,47 @@ TEST_F(McapConvertTest, missing_input)
     ASSERT_EQ(ret, eprosima::ddsrecorder::converter::ProcessReturnCode::incorrect_argument);
 }
 
+TEST_F(McapConvertTest, custom_sql_batch_size_argument)
+{
+    const auto input_file = recordings_root_() / "basic" / "configuration.mcap";
+    std::vector<std::string> args = {
+        "mcap-convert",
+        "--input-file",
+        input_file.string(),
+        "--sql-batch-size",
+        "32"};
+    auto argv = argv_from_(args);
+    auto commandline_args = eprosima::ddsrecorder::converter::CommandlineArgsMcapConvert();
+
+    const auto ret = eprosima::ddsrecorder::converter::parse_arguments(
+        static_cast<int>(argv.size()),
+        argv.data(),
+        commandline_args);
+
+    ASSERT_EQ(ret, eprosima::ddsrecorder::converter::ProcessReturnCode::success);
+    ASSERT_EQ(commandline_args.sql_batch_size, 32u);
+}
+
+TEST_F(McapConvertTest, zero_sql_batch_size_argument_is_invalid)
+{
+    const auto input_file = recordings_root_() / "basic" / "configuration.mcap";
+    std::vector<std::string> args = {
+        "mcap-convert",
+        "--input-file",
+        input_file.string(),
+        "--sql-batch-size",
+        "0"};
+    auto argv = argv_from_(args);
+    auto commandline_args = eprosima::ddsrecorder::converter::CommandlineArgsMcapConvert();
+
+    const auto ret = eprosima::ddsrecorder::converter::parse_arguments(
+        static_cast<int>(argv.size()),
+        argv.data(),
+        commandline_args);
+
+    ASSERT_EQ(ret, eprosima::ddsrecorder::converter::ProcessReturnCode::incorrect_argument);
+}
+
 TEST_F(McapConvertTest, default_output)
 {
     const auto source_input_file = recordings_root_() / "basic" / "configuration.mcap";
@@ -198,6 +239,32 @@ TEST_F(McapConvertTest, ros2_output_exact_counts)
         configuration_,
         commandline_args_.input_file,
         output_file.string());
+    converter.convert();
+
+    ASSERT_TRUE(std::filesystem::exists(output_file));
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM Messages;"), 35);
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM MessagesPartitions;"), 35);
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM Topics;"), 4);
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM Types;"), 20);
+    ASSERT_EQ(
+        count_query_(output_file, "SELECT COUNT(*) FROM Messages WHERE data_json IS NOT NULL AND data_json != '';"),
+        22);
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM Messages WHERE key != '';"), 22);
+}
+
+TEST_F(McapConvertTest, ros2_output_exact_counts_with_small_batch)
+{
+    const auto input_file = recordings_root_() / "ros2" / "ros2_talker.mcap";
+    const auto output_file = output_directory_ / "ros2_output_small_batch.db";
+
+    commandline_args_.input_file = input_file.string();
+    commandline_args_.sql_batch_size = 4u;
+
+    eprosima::ddsrecorder::converter::McapToSqlConverter converter(
+        configuration_,
+        commandline_args_.input_file,
+        output_file.string(),
+        commandline_args_.sql_batch_size);
     converter.convert();
 
     ASSERT_TRUE(std::filesystem::exists(output_file));

--- a/converter/mcap_convert_tool/test/blackbox/McapConvertTest.cpp
+++ b/converter/mcap_convert_tool/test/blackbox/McapConvertTest.cpp
@@ -190,6 +190,26 @@ TEST_F(McapConvertTest, zero_sql_batch_size_argument_is_invalid)
     ASSERT_EQ(ret, eprosima::ddsrecorder::converter::ProcessReturnCode::incorrect_argument);
 }
 
+TEST_F(McapConvertTest, negative_sql_batch_size_argument_is_invalid)
+{
+    const auto input_file = recordings_root_() / "basic" / "configuration.mcap";
+    std::vector<std::string> args = {
+        "mcap-convert",
+        "--input-file",
+        input_file.string(),
+        "--sql-batch-size",
+        "-1"};
+    auto argv = argv_from_(args);
+    auto commandline_args = eprosima::ddsrecorder::converter::CommandlineArgsMcapConvert();
+
+    const auto ret = eprosima::ddsrecorder::converter::parse_arguments(
+        static_cast<int>(argv.size()),
+        argv.data(),
+        commandline_args);
+
+    ASSERT_EQ(ret, eprosima::ddsrecorder::converter::ProcessReturnCode::incorrect_argument);
+}
+
 TEST_F(McapConvertTest, default_output)
 {
     const auto source_input_file = recordings_root_() / "basic" / "configuration.mcap";

--- a/converter/mcap_convert_tool/test/blackbox/McapConvertTest.cpp
+++ b/converter/mcap_convert_tool/test/blackbox/McapConvertTest.cpp
@@ -187,6 +187,30 @@ TEST_F(McapConvertTest, explicit_output)
     ASSERT_GT(count_query_(output_file, "SELECT COUNT(*) FROM Messages WHERE key != '';"), 0);
 }
 
+TEST_F(McapConvertTest, ros2_output_exact_counts)
+{
+    const auto input_file = recordings_root_() / "ros2" / "ros2_talker.mcap";
+    const auto output_file = output_directory_ / "ros2_output.db";
+
+    commandline_args_.input_file = input_file.string();
+
+    eprosima::ddsrecorder::converter::McapToSqlConverter converter(
+        configuration_,
+        commandline_args_.input_file,
+        output_file.string());
+    converter.convert();
+
+    ASSERT_TRUE(std::filesystem::exists(output_file));
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM Messages;"), 35);
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM MessagesPartitions;"), 35);
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM Topics;"), 4);
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM Types;"), 20);
+    ASSERT_EQ(
+        count_query_(output_file, "SELECT COUNT(*) FROM Messages WHERE data_json IS NOT NULL AND data_json != '';"),
+        22);
+    ASSERT_EQ(count_query_(output_file, "SELECT COUNT(*) FROM Messages WHERE key != '';"), 22);
+}
+
 int main(
         int argc,
         char** argv)

--- a/ddsrecorder/test/blackbox/both/ResourceLimitsTest.cpp
+++ b/ddsrecorder/test/blackbox/both/ResourceLimitsTest.cpp
@@ -425,7 +425,7 @@ protected:
         if (file_type == test::FileTypes::MCAP)
         {
             ASSERT_TRUE(false) <<
-                "This test is not useful. Maybe throw an exception if in MCAP the max_size and log_rotation is set but no max_file_size? It would overwritting the same file over and over";
+                "This test is not useful. Maybe throw an exception if in MCAP the max_size and log_rotation is set but no max_file_size? It would overwriting the same file over and over";
             return;
         }
 

--- a/ddsrecorder/test/blackbox/both/ResourceLimitsTest.cpp
+++ b/ddsrecorder/test/blackbox/both/ResourceLimitsTest.cpp
@@ -208,8 +208,7 @@ protected:
 
     std::filesystem::path get_output_file_path_(
             const std::string& output_file_name,
-            const test::FileTypes file_type
-            )
+            const test::FileTypes file_type)
     {
         if (file_type == test::FileTypes::SQL)
         {
@@ -246,10 +245,9 @@ protected:
 
         if (!is_acceptable)
         {
-            std::cout << "is_file_size_acceptable_: File " << file_path << " has an unacceptable size of " <<
-                file_size << " bytes, when limits: "
-                      << limits_->MIN_ACCEPTABLE_FILE_SIZE << " <= size <= " << limits_->MAX_ACCEPTABLE_FILE_SIZE <<
-                std::endl;
+            std::cout << "is_file_size_acceptable_: File " << file_path << " has an unacceptable size of "
+                      << file_size << " bytes, when limits: " << limits_->MIN_ACCEPTABLE_FILE_SIZE
+                      << " <= size <= " << limits_->MAX_ACCEPTABLE_FILE_SIZE << std::endl;
         }
         return is_acceptable;
     }
@@ -424,7 +422,8 @@ protected:
     {
         if (file_type == test::FileTypes::MCAP)
         {
-            ASSERT_TRUE(false) <<
+            ASSERT_TRUE(false)
+                <<
                 "This test is not useful. Maybe throw an exception if in MCAP the max_size and log_rotation is set but no max_file_size? It would overwriting the same file over and over";
             return;
         }

--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/handler/sql/SqlWriter.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/handler/sql/SqlWriter.hpp
@@ -51,7 +51,7 @@ public:
      *
      * @throws \c InconsistencyException if there is a database error
      */
-    template <typename T>
+    template<typename T>
     void write(
             const T& data);
 
@@ -129,7 +129,7 @@ protected:
      *
      * @throws \c InconsistencyException if there is a database error
      */
-    template <typename T>
+    template<typename T>
     void write_nts_(
             const T& data);
 

--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/handler/sql/SqlWriter.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/handler/sql/SqlWriter.hpp
@@ -27,6 +27,7 @@
 #include <ddsrecorder_participants/library/library_dll.h>
 #include <ddsrecorder_participants/recorder/handler/BaseWriter.hpp>
 #include <ddsrecorder_participants/recorder/handler/sql/SqlHandlerConfiguration.hpp>
+#include <ddsrecorder_participants/recorder/message/SqlMessage.hpp>
 
 namespace eprosima {
 namespace ddsrecorder {
@@ -53,6 +54,24 @@ public:
     template <typename T>
     void write(
             const T& data);
+
+    /**
+     * @brief Writes topic metadata to the output file.
+     */
+    void write_topic(
+            const ddspipe::core::types::DdsTopic& topic);
+
+    /**
+     * @brief Writes a partition name to the output file.
+     */
+    void write_partition_name(
+            const std::string& partition);
+
+    /**
+     * @brief Writes a batch of SQL messages to the output file.
+     */
+    void write_messages(
+            const std::vector<SqlMessage>& messages);
 
     /**
      *

--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/message/BaseMessage.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/message/BaseMessage.hpp
@@ -27,6 +27,8 @@
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 #include <ddspipe_core/efficiency/payload/PayloadPool.hpp>
 
+#include <ddsrecorder_participants/library/library_dll.h>
+
 
 namespace eprosima {
 namespace ddsrecorder {
@@ -35,7 +37,7 @@ namespace participants {
 /**
  * Structure implementing a DDS Message with a Fast-DDS payload and its owner (a \c PayloadPool).
  */
-struct BaseMessage
+struct DDSRECORDER_PARTICIPANTS_DllAPI BaseMessage
 {
     BaseMessage() = default;
 

--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/message/SqlMessage.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/message/SqlMessage.hpp
@@ -89,7 +89,7 @@ struct DDSRECORDER_PARTICIPANTS_DllAPI SqlMessage : public BaseMessage
     ddspipe::core::types::Guid writer_guid;
 
     // Cached string form of the writer GUID when already available
-    // Used to reduce the time complexity of writting in SQL files
+    // Used to reduce the time complexity of writing in SQL files
     std::string writer_guid_string;
 
     // Number of SqlMessages created

--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/message/SqlMessage.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/message/SqlMessage.hpp
@@ -42,7 +42,7 @@ namespace participants {
 /**
  * Structure extending a \c BaseMessage for SQLite.
  */
-struct SqlMessage : public BaseMessage
+struct DDSRECORDER_PARTICIPANTS_DllAPI SqlMessage : public BaseMessage
 {
     SqlMessage() = default;
 

--- a/ddsrecorder_participants/include/ddsrecorder_participants/recorder/message/SqlMessage.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/recorder/message/SqlMessage.hpp
@@ -88,6 +88,10 @@ struct SqlMessage : public BaseMessage
     // Writer GUID
     ddspipe::core::types::Guid writer_guid;
 
+    // Cached string form of the writer GUID when already available
+    // Used to reduce the time complexity of writting in SQL files
+    std::string writer_guid_string;
+
     // Number of SqlMessages created
     static std::atomic<std::uint64_t> number_of_msgs;
 
@@ -102,6 +106,13 @@ struct SqlMessage : public BaseMessage
 
     // String containing the JSON-serialized instance key
     std::string key;
+
+    // Partition assigned to the message writer
+    std::string partition;
+
+    // Cached SQL-formatted timestamps when already available.
+    std::string log_time_sql;
+    std::string publish_time_sql;
 };
 
 } /* namespace participants */

--- a/ddsrecorder_participants/include/ddsrecorder_participants/replayer/BaseReaderParticipant.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/replayer/BaseReaderParticipant.hpp
@@ -190,6 +190,7 @@ protected:
      * @param raw_data: Raw data to be encapsulated in the payload.
      * @param raw_data_size: Size of the raw data.
      */
+    DDSRECORDER_PARTICIPANTS_DllAPI
     std::unique_ptr<ddspipe::core::types::RtpsPayloadData> create_payload_(
             const void* raw_data,
             const std::uint32_t raw_data_size);

--- a/ddsrecorder_participants/include/ddsrecorder_participants/replayer/McapReaderParticipant.hpp
+++ b/ddsrecorder_participants/include/ddsrecorder_participants/replayer/McapReaderParticipant.hpp
@@ -106,11 +106,13 @@ protected:
      *
      * @throws \c InitializationException if failed to open MCAP file.
      */
+    DDSRECORDER_PARTICIPANTS_DllAPI
     void open_file_();
 
     /**
      * @brief Close the MCAP file.
      */
+    DDSRECORDER_PARTICIPANTS_DllAPI
     void close_file_();
 
     /**

--- a/ddsrecorder_participants/src/cpp/common/time_utils.cpp
+++ b/ddsrecorder_participants/src/cpp/common/time_utils.cpp
@@ -21,6 +21,7 @@
 #include <ctime>
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
 
 #include <cpp_utils/time/time_utils.hpp>
 
@@ -33,6 +34,28 @@ namespace participants {
 
 const auto SQL_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S";
 constexpr std::uint64_t NS_PER_SEC = 1000000000;
+
+namespace {
+
+bool fill_calendar_time_(
+        const std::time_t& time_seconds,
+        const bool local_time,
+        std::tm& calendar_time)
+{
+#if defined(_WIN32)
+    const auto ret = local_time ?
+            localtime_s(&calendar_time, &time_seconds) :
+            gmtime_s(&calendar_time, &time_seconds);
+    return ret == 0;
+#else
+    const auto* ret = local_time ?
+            localtime_r(&time_seconds, &calendar_time) :
+            gmtime_r(&time_seconds, &calendar_time);
+    return ret != nullptr;
+#endif // defined(_WIN32)
+}
+
+} // namespace
 
 utils::Timestamp to_std_timestamp(
         const mcap::Timestamp& time)
@@ -90,9 +113,15 @@ std::string to_sql_timestamp(
 {
     char datetime_str[30];
 
-    const std::time_t time_seconds = time.seconds();
-    const auto time_seconds_zone = local_time ? std::localtime(&time_seconds) : std::gmtime(&time_seconds);
-    std::strftime(datetime_str, sizeof(datetime_str), SQL_TIMESTAMP_FORMAT, time_seconds_zone);
+    const std::time_t time_seconds = static_cast<std::time_t>(time.seconds());
+    std::tm calendar_time{};
+
+    if (!fill_calendar_time_(time_seconds, local_time, calendar_time))
+    {
+        throw std::runtime_error("Failed to format SQL timestamp.");
+    }
+
+    std::strftime(datetime_str, sizeof(datetime_str), SQL_TIMESTAMP_FORMAT, &calendar_time);
 
     // Combine the date-time string with nanoseconds to form the full timestamp
     std::ostringstream oss;

--- a/ddsrecorder_participants/src/cpp/recorder/handler/sql/SqlWriter.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/handler/sql/SqlWriter.cpp
@@ -446,7 +446,7 @@ void SqlWriter::write_nts_(
 
         sqlite3_bind_text(statement_partition, 1, writer_guid_str.c_str(), -1, SQLITE_TRANSIENT);
         sqlite3_bind_int64(statement_partition, 2, message.sequence_number.to64long());
-        
+
         // Get the partition from the message if available, to reduce time complexity
         const auto& partitions_set_string = message.partition.empty() ? [&message,
                         &writer_guid_str]()->const std::string &

--- a/ddsrecorder_participants/src/cpp/recorder/handler/sql/SqlWriter.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/handler/sql/SqlWriter.cpp
@@ -230,7 +230,7 @@ void SqlWriter::open_new_file_nts_(
 }
 
 // (Tables: Types)
-template <>
+template<>
 void SqlWriter::write_nts_(
         const DynamicType& dynamic_type)
 {
@@ -318,7 +318,7 @@ void SqlWriter::write_nts_(
 }
 
 // (Tables: Messages and MessagesPartitions)
-template <>
+template<>
 void SqlWriter::write_nts_(
         const std::vector<SqlMessage>& messages)
 {
@@ -350,9 +350,9 @@ void SqlWriter::write_nts_(
 
     if (prep_ret != SQLITE_OK)
     {
-        const std::string error_msg = utils::Formatter() <<
-                "Failed to prepare SQL statement to write in Messages table: " <<
-                sqlite3_errmsg(database_);
+        const std::string error_msg = utils::Formatter()
+                << "Failed to prepare SQL statement to write in Messages table: "
+                << sqlite3_errmsg(database_);
         sqlite3_finalize(statement_message);
 
         EPROSIMA_LOG_ERROR(DDSRECORDER_SQL_WRITER, "FAIL_SQL_WRITE | " << error_msg);
@@ -366,9 +366,9 @@ void SqlWriter::write_nts_(
 
     if (prep_ret_partition != SQLITE_OK)
     {
-        const std::string error_msg = utils::Formatter() <<
-                "Failed to prepare SQL statement to write in MessagesPartitions table: " <<
-                sqlite3_errmsg(database_);
+        const std::string error_msg = utils::Formatter()
+                << "Failed to prepare SQL statement to write in MessagesPartitions table: "
+                << sqlite3_errmsg(database_);
         sqlite3_finalize(statement_message);
         sqlite3_finalize(statement_partition);
 
@@ -393,16 +393,21 @@ void SqlWriter::write_nts_(
         // (Table: Messages) Bind the SqlMessage to the SQL statement
 
         // Bind the sample identity
-        std::ostringstream writer_guid_ss;
-        std::string writer_guid_str;
-        writer_guid_ss << message.writer_guid;
-        writer_guid_str = writer_guid_ss.str();
+        // Get the writer_guid from the message if available, to reduce time complexity
+        std::string writer_guid_str = message.writer_guid_string;
+        if (writer_guid_str.empty())
+        {
+            std::ostringstream writer_guid_ss;
+            writer_guid_ss << message.writer_guid;
+            writer_guid_str = writer_guid_ss.str();
+        }
 
         sqlite3_bind_text(statement_message, 1, writer_guid_str.c_str(), -1, SQLITE_TRANSIENT);
         sqlite3_bind_int64(statement_message, 2, message.sequence_number.to64long());
 
         // Bind the sample data
-        std::string data_json = "";
+        static const std::string empty_string;
+        const std::string* data_json = &empty_string;
         // Empty data_cdr aux to avoid binding nullptr
         std::byte data_cdr_aux = std::byte(0);
         std::byte* data_cdr = &data_cdr_aux;
@@ -410,7 +415,7 @@ void SqlWriter::write_nts_(
 
         if (data_format_ == DataFormat::both || data_format_ == DataFormat::json)
         {
-            data_json = message.data_json;
+            data_json = &message.data_json;
         }
 
         if (data_format_ == DataFormat::both || data_format_ == DataFormat::cdr)
@@ -419,7 +424,7 @@ void SqlWriter::write_nts_(
             data_cdr_size = message.get_data_cdr_size();
         }
 
-        sqlite3_bind_text(statement_message, 3, data_json.c_str(), -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement_message, 3, data_json->c_str(), -1, SQLITE_TRANSIENT);
         sqlite3_bind_blob(statement_message, 4, data_cdr, data_cdr_size, SQLITE_TRANSIENT);
         sqlite3_bind_int64(statement_message, 5, data_cdr_size);
 
@@ -429,23 +434,27 @@ void SqlWriter::write_nts_(
         sqlite3_bind_text(statement_message, 8, message.key.c_str(), -1, SQLITE_TRANSIENT);
 
         // Bind the time data
-        sqlite3_bind_text(statement_message, 9, to_sql_timestamp(message.log_time).c_str(), -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(statement_message, 10, to_sql_timestamp(message.publish_time).c_str(), -1, SQLITE_TRANSIENT);
+        const auto& log_time_str =
+                message.log_time_sql.empty() ? to_sql_timestamp(message.log_time) : message.log_time_sql;
+        const auto& publish_time_str =
+                message.publish_time_sql.empty() ? to_sql_timestamp(message.publish_time) : message.publish_time_sql;
+        sqlite3_bind_text(statement_message, 9, log_time_str.c_str(), -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement_message, 10, publish_time_str.c_str(), -1, SQLITE_TRANSIENT);
 
 
         // (Table: MessagesPartitions)
 
         sqlite3_bind_text(statement_partition, 1, writer_guid_str.c_str(), -1, SQLITE_TRANSIENT);
         sqlite3_bind_int64(statement_partition, 2, message.sequence_number.to64long());
-
-        std::string partitions_set_string = "";
-
-        // Search for the partitions set with the writed_guid in the current Topic
-        auto it = message.topic.partition_name.find(writer_guid_str);
-        if (it != message.topic.partition_name.end())
+        
+        // Get the partition from the message if available, to reduce time complexity
+        const auto& partitions_set_string = message.partition.empty() ? [&message,
+                        &writer_guid_str]()->const std::string &
         {
-            partitions_set_string = it->second;
-        }
+            static const std::string empty_partition;
+            const auto it = message.topic.partition_name.find(writer_guid_str);
+            return it != message.topic.partition_name.end() ? it->second : empty_partition;
+        } () : message.partition;
 
         sqlite3_bind_text(statement_partition, 3, partitions_set_string.c_str(), -1, SQLITE_TRANSIENT);
 
@@ -460,14 +469,14 @@ void SqlWriter::write_nts_(
         // (Table: Messages) Entry size
         entry_size_message += entry_size_writer_guid;
         entry_size_message += entry_size_sequence_number;
-        entry_size_message += data_json.size();
+        entry_size_message += data_json->size();
         entry_size_message += data_cdr_size;
         entry_size_message += calculate_int_storage_size(data_cdr_size);
         entry_size_message += message.topic.topic_name().size();
         entry_size_message += message.topic.type_name.size();
         entry_size_message += message.key.size();
-        entry_size_message += to_sql_timestamp(message.log_time).size();
-        entry_size_message += to_sql_timestamp(message.publish_time).size();
+        entry_size_message += log_time_str.size();
+        entry_size_message += publish_time_str.size();
 
         // (Table: MessagesPartitions) Entry size
         entry_size_partition += entry_size_writer_guid;
@@ -551,7 +560,7 @@ void SqlWriter::write_nts_(
 }
 
 // (Tables: Topics)
-template <>
+template<>
 void SqlWriter::write_nts_(
         const ddspipe::core::types::DdsTopic& topic)
 {
@@ -639,7 +648,7 @@ void SqlWriter::write_nts_(
 }
 
 // (Tables: Partitions)
-template <>
+template<>
 void SqlWriter::write_nts_(
         const std::string& partition_set)
 {

--- a/ddsrecorder_participants/src/cpp/recorder/handler/sql/SqlWriter.cpp
+++ b/ddsrecorder_participants/src/cpp/recorder/handler/sql/SqlWriter.cpp
@@ -66,6 +66,24 @@ void SqlWriter::update_dynamic_types(
     dynamic_types_.push_back(dynamic_type);
 }
 
+void SqlWriter::write_topic(
+        const ddspipe::core::types::DdsTopic& topic)
+{
+    write(topic);
+}
+
+void SqlWriter::write_partition_name(
+        const std::string& partition)
+{
+    write(partition);
+}
+
+void SqlWriter::write_messages(
+        const std::vector<SqlMessage>& messages)
+{
+    write(messages);
+}
+
 void SqlWriter::open_new_file_nts_(
         const std::uint64_t min_file_size)
 {

--- a/docs/rst/replaying/usage/mcap_convert.rst
+++ b/docs/rst/replaying/usage/mcap_convert.rst
@@ -36,6 +36,18 @@ To write the converted output to a specific location, pass ``--sql-output``:
 
 If the value given to ``--sql-output`` has no extension, ``.db`` is appended automatically.
 
+To tune the conversion batch size, use ``--sql-batch-size``:
+
+.. code-block:: bash
+
+    source install/setup.bash
+    mcap-convert -i /path/to/recording.mcap --sql-batch-size 8192
+
+The batch size controls how many messages are processed before they are written to the SQLite
+output. The default value is ``4096``. Larger values can improve throughput at the cost of higher
+memory usage, while smaller values reduce memory usage and force more frequent flushes. The value
+must be greater than ``0``.
+
 Optional Configuration File
 ===========================
 
@@ -102,6 +114,14 @@ The ``mcap-convert`` application supports the following input arguments:
         - File path
         - Input file path with ``.db`` |br|
           extension
+
+    *   - SQL Batch Size
+        - Number of messages processed |br|
+          before flushing a batch into |br|
+          the SQLite output.
+        - ``--sql-batch-size``
+        - Integer greater than ``0``
+        - ``4096``
 
     *   - Debug
         - Enables the converter logs so the |br|


### PR DESCRIPTION
## Description

This PR significantly improves `mcap-convert` performance by removing replay-oriented overhead from the conversion path and parallelizing the most expensive CPU-bound work, while keeping the SQL schema and output semantics unchanged.

It also adds a new **CLI argument,** `--sql-batch-size`, to configure the SQL conversion batch size. The default value is `4096`.

## What changed
- Set a batch, instead of going 1 message
- Split conversion into two stages
  -  **Sequential MCAP scan** and `SqlMessage` capture
  -  **Parallel per-batch hydration**
- Reused per-worker dynamic serialization contexts instead of constructing `DynamicPubSubType` and `DynamicData` for every message.
- Added cached fields to `SqlMessage` for `writer_guid`, `partition`, `log_time_sql`, and `publish_time_sql`, to reduce time complexity in SQL files, by trying to consume those cached values when available, while preserving the previous fallback behavior for other call sites.
- Kept SQLite writes batched and sequential, so database output remains consistent and deterministic.

## Performance results

```
Load publisher summary:
  configured topic count: 65
  configured total messages: 260000
  actual sent total: 260000
  per-topic target count: 4000 each
  elapsed publish time: 900 seconds
```

### - Before: ~30min
### - This PR: 6s